### PR TITLE
Fix #128, #139, #154 and #168

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -865,7 +865,6 @@ class sync_obu() {
     unsigned int (6) reserved;
     sleb128() relative_offset;
   }
-  leb128() concatenation_rule;
 }
 ```
 
@@ -897,9 +896,11 @@ For this version of the specification, the value of reinitialize_decoder shall b
 
 <dfn value noexport for="sync_obu()">reserved</dfn> shall be set to 0. Reserved units are for future use and shall be ignored by an IAC-OBU parser.
 
-<dfn noexport>relative_offset</dfn> is the offset that is applied to the first audio frame or parameter block with the referenced obu_id that comes after this Sync OBU. It describes the position of audio and parameters in a local frame of reference. The local frame of reference is unique for each Sync OBU.
+<dfn noexport>relative_offset</dfn> is the offset that is applied to the first audio frame or parameter block with the referenced obu_id that comes after this Sync OBU to position the first audio frame or parameter block with respect to the timeline generated before this Sync OBU. In other words, it is the offset from the timeline of Substreams generated from the previous Sync OBU.
 
-<dfn noexport>concatenation_rule</dfn> shall specify the type of concatenation rule that is applied to position the audio frames and parameters that happened after a Sync OBU with respect to the timeline before the Sync OBU. A value of 0 shall indicate that Concatenation Rule 1 specified in [[#standalone-synchronizing-data-obus]] shall be used, while a value of 1 shall indicate that Concatenation Rule 2 shall be used.
+The offset shall be indicated in the number of ticks at the time_base specified in the corresponding substream or parameter definition.
+
+IA encoder and decoder operations related to this field are specified in [[#standalone-synchronizing-data-obus]].
 
 ## Detailed OBU Syntax and Semantics ## {#syntax-detailed}
 
@@ -1506,104 +1507,83 @@ The Sync OBU contains two pieces of information that apply to all substream and 
 
 2) a global offset.
 
-The relative offsets describe how the substreams and parameters are positioned within a local frame of reference, which is unique for each Sync OBU. For example, the Sync OBU given below indicates that Substream 1 has a start timestamp that is 15 units before Substream 2, 10 units after Parameter 1, and 25 units before Parameter 2.
+The relative offsets describe how the substreams and parameters are positioned with respect to the timeline of Substreams generated from the previous Sync OBU. For example, from the previous Sync OBU, Substream 1 has a end timestamp 960 units, Substream 2 has a end timestamp 1024 units, Parameter 1 has a end timestamp 900 units and Parameter 2 has a end timestamp 1100 units. The relative offsets are calculated with respect to the maximum timeline of Substreams (i.e. 1024 units). So, Subsream 1 has a relative offset that is 64 units before Substream 2, Substream 2 has  a relative offset that is 0 unit, Parameter 1 has a relative offset that is 124 units before Substream 2 and Parameter 2 has a relative offset that is 76 after Substream 2.
 
 <table class="def">
 <tr>
-  <th>ID (name)</th><th>Relative offset</th>
-</tr>
-<tr>
-  <td>N/A (Global offset)</td><td>0</td>
-</td>
-</tr>
-  <td>1 (Substream 1)</td><td>-5</td>
-</td>
-</tr>
-  <td>2 (Substream 2)</td><td>+10</td>
-</td>
-</tr>
-  <td>3 (Parameter 1)</td><td>-15</td>
-</td>
-</tr>
-  <td>4 (Parameter 2)</td><td>+20</td>
-</tr>
-</table>
-
-Within a Sync OBU, only the relative information between the relative offsets is meaningful for positioning it within the global frame of reference, where the method of positioning is described further below. This is not affected by any constant shift in the relative offsets. As such, each Sync OBU can have any number of variants, as long as there is a constant difference between the two variants (see the example below). This removes any restrictions on how the absolute values of the relative offsets are selected. For example, some implementations may wish to always set the relative offset of an arbitrarily selected substream or parameter to 0.
-
-<table class="def">
-<tr>
-  <th>ID (name)</th><th>Relative offset (variant 1)</th><th>Relative offset (variant 2)</th>
+  <th>ID (name)</th><th>end timestamp</th><th>Relative offset</th>
 </tr>
 <tr>
   <td>N/A (Global offset)</td><td>0</td><td>0</td>
 </td>
 </tr>
-  <td>1 (Substream 1)</td><td>-5</td><td>+10</td>
+  <td>1 (Substream 1)</td><td>960</td><td>-64</td>
 </td>
 </tr>
-  <td>2 (Substream 2)</td><td>+40</td><td>+55</td>
+  <td>2 (Substream 2)</td><td>1024</td><td>+0</td>
 </td>
 </tr>
-  <td>3 (Parameter 1)</td><td>-15</td><td>0</td>
+  <td>3 (Parameter 1)</td><td>900</td><td>-124</td>
 </td>
 </tr>
-  <td>4 (Parameter 2)</td><td>+20</td><td>+35</td>
+  <td>4 (Parameter 2)</td><td>1100</td><td>+76</td>
 </tr>
 </table>
 
-The global offset defines an additional offset that is applied to all substreams and parameters, and can be used to express intentional gaps between the substreams and parameters associated with two Sync OBUs.
+The global offset defines an additional offset that is applied to all substreams and parameters, and can be used to express intentional gaps between the local frames associated with two Sync OBUs.
 
-The local frame of reference can be positioned in a global frame of reference by using one of the two concatenation rules provided below. These rules specify how two timelines associated with different Sync OBUs shall be aligned.
+The local frame of reference can be positioned in a global frame of reference by using the concatenation rule provided below. This rule specify how two timelines associated with different Sync OBUs shall be aligned.
 
-<dfn noexport>Concatenation Rule 1</dfn>
+<dfn noexport>Concatenation Rule</dfn>
 
-Ignoring the global offset, the new timeline after a Sync OBU is shifted as early as possible such that the earliest substream or parameter in the new timeline concatenates with its counterpart in the previous timeline. Then, the global offset is applied to additionally shift the new timeline.
+Ignoring the global offset, the new timeline after a Sync OBU is extended based on the timeline generated from the previous Sync OBU and relative offsets in the current Sync OBU. Then, the global offset is applied to additionally shift the new timeline.
 
-<dfn noexport>Concatenation Rule 2</dfn>
 
-Ignoring the global offset, the new timeline after a Sync OBU is shifted as early as possible such that the earliest substream in the new timeline concatenates with the latest substream in the old timeline. Then, the global offset is applied to additionally shift the new timeline.
-
-ISSUE: Choose if this applies to 1) all audio substreams + params, or to 2) audio substreams only. Option 1) can lead to audio gaps. 2) can lead to overlapping params. See https://github.com/AOMediaCodec/iac/issues/102
-
-The algorithm below may be used to implement the concatenation rules.
+The algorithm below may be used to implement the concatenation rule. But, the result shall comply with this.
 
 ```
-// Timestamp at the end of the most recent frame before the Sync OBU, for a
-// given substream or parameter ID.
-end_timestamp\[ID];
+For a given ID, end_timestamp\[ID]\[0] = 0 (i.e. initial value = 0)
 
-// Offset specified by the new Sync OBU.
-relative_offset\[ID];
+Encoder operation for the Nth Sync OBU 
+// Encoders know the position of an OBU on global timeline. 
+// So, they know start_timestamp\[ID]\[N] and global_offset\[N].
 
-if (concatenation_rule_1) {
-  // The timestamp for the “zero offset” is computed by applying relativ
-  // offsets to the end timestamps, and seeing which one comes latest in time.
-  timestamp_for_zero_offset =
-    max(end_timestamp\[ID] - relative_offset\[ID] for each ID)
-    + global_offset;
+For each ID in the Nth Sync OBU.
+
+relative_offset\[ID]\[N] = start_timestamp\[ID]\[N] - global_offset\[N]
+                           - max(end_timestamp\[ID]\[N-1] for each audio frame ID);
+// i.e. relative_offset\[ID]\[1] = start_timestamp\[ID]\[1] 
+//                                 - global_offset\[1] for the first Sync OBU.
+
+// end_timestamp\[ID]\[N] for each ID is calculated as follows:
+
+end_timestamp\[ID]\[N] = start_timestamp\[ID]\[N];
+
+for (i = 0: i < M(N); i++) {
+  end_timestamp\[ID]\[N] += frame size of ith audio frame
+                            (or duration of ith parameter block) having the ID;
 }
+// M(N) is the number of audio frame OBUs(or parameter block OBUs) having the given ID
+// between the Nth Sync OBU and the (N+1)th Sync OBU.
 
-if (concatenation_rule_2) {
-  timestamp_for_zero_offset =
-    max(end_timestamp\[ID]) - min(relative_offset\[ID])
-    + global_offset;
+Decoder operation for the Nth Sync OBU 
+// Decoders need to extend the timeline generated from the previous Sync OBU.
+
+For each ID in the Nth Sync OBU.
+
+start_timestamp\[ID]\[N] = max(end_timestamp\[ID]\[N-1] for each audio frame ID)
+                           + relative_offset\[ID]\[N] + globl_offset\[N];
+
+end_timestamp\[ID]\[N] = start_timestamp\[ID]\[N];
+
+for (i = 0: i < M(N); i++) {
+  end_timestamp\[ID]\[N] += frame size of ith audio frame
+                            (or duration of ith parameter block) having the ID;
 }
-
-// Find the timestamp of each substream and parameter relative to the new
-// “zero”.
-For each ID:
-  next_start_timestamp\[ID] = timestamp_for_zero_offset + relative_offset\[ID]
+// M(N) is the number of audio frame OBUs
+// (or parameter block OBUs) having the given ID
+// between the Nth Sync OBU and the (N+1)th Sync OBU.
 ```
-
-The example below illustrates three examples of how the same timeline after (orange and blue) is aligned with different previous timelines (white) when using Concatenation Rule 1.
-
-<center><img src="images/sync_obu_concat_rule.png" style="width:100%; height:auto;"></center>
-<center><figcaption>Aligning timelines before and after a Sync OBU using the concatenation rule.</figcaption></center>
-
-ISSUE: Add a similar diagram for Concat Rule 2 when its corresponding issue is resolved.
-
-Since the Data OBUs between two Sync OBUs must be gapless, the remainder of the timeline can be inferred from the durations of the audio frames and parameter blocks. The duration of an audio frame is specified by the [=num_samples_per_frame=] field in its corresponding Codec Config OBU, while the duration of a parameter block is specified in its [=duration=] field.
 
 
 # ISOBMFF IAC Encapsulation # {#isobmff}

--- a/index.bs
+++ b/index.bs
@@ -896,9 +896,9 @@ For this version of the specification, the value of reinitialize_decoder shall b
 
 <dfn value noexport for="sync_obu()">reserved</dfn> shall be set to 0. Reserved units are for future use and shall be ignored by an IAC-OBU parser.
 
-<dfn noexport>relative_offset</dfn> is the offset that is applied to the first audio frame or parameter block with the referenced obu_id that comes after this Sync OBU to position the first audio frame or parameter block with respect to the timeline generated before this Sync OBU. In other words, it is the offset from the timeline of Substreams generated from the previous Sync OBU.
+<dfn noexport>relative_offset</dfn> is the offset to position the first audio frame (before trimming) or parameter block with the referenced obu_id that comes after this Sync OBU with respect to the timeline generated before this Sync OBU. If this Sync OBU is the first one, it is the offset from 0. Otherwise, it is the offset from the end of the timeline of Substreams generated from the previous Sync OBU.
 
-The offset shall be indicated in the number of ticks at the time_base specified in the corresponding substream or parameter definition.
+The offset shall be indicated in the number of ticks at the time_base specified in the corresponding substream or parameter definition. 
 
 IA encoder and decoder operations related to this field are specified in [[#standalone-synchronizing-data-obus]].
 

--- a/index.bs
+++ b/index.bs
@@ -1568,6 +1568,7 @@ for (i = 0: i < M(N); i++) {
 
 Decoder operation for the Nth Sync OBU 
 // Decoders need to extend the timeline generated from the previous Sync OBU.
+// For the first Sync OBU which decoders get after join mid-stream, N is set to 1.
 
 For each ID in the Nth Sync OBU.
 


### PR DESCRIPTION
I updated Sync OBU based on the discussions on #168. But, I just remained global_offset to keep the current syntax structure as possible as we can.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/pull/186.html" title="Last updated on Nov 22, 2022, 5:11 AM UTC (12fca8d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/186/a997123...12fca8d.html" title="Last updated on Nov 22, 2022, 5:11 AM UTC (12fca8d)">Diff</a>