### PR TITLE
Fix #131 and Fix #132

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1140,6 +1140,12 @@ class recon_gain_info() {
 
 <left><img src="images/Recon_Gain_Flags.png" style="width:100%; height:auto;"></left>
 
+The each bit of [=recon_gain_flags=] indicates the presence of [=recon_gain=] applied to the channel as depicted in the above figure.
+ - 0: It shall indicate that no [=recon_gain=] presents for the channel.
+ - 1: It shall indicate that [=recon_gain=] presents for the channel.
+
+<dfn noexport>n(i)</dfn> shall indicate the number of bits for recon_gain_flag(i). It shall be 7 or 12 as depicted in the about figure. Where, i = 0, 1, ..., [=num_layers=] - 1.
+
 <dfn noexport>recon_gain</dfn> shall indicate the gain value to be applied to the channel, which is indicated by [=recon_gain_flags=], after decoding of the following associated frames.
 
 ### Mix Target Layout Syntax and Semantics ### {#syntax-mix-target-layout}

--- a/index.bs
+++ b/index.bs
@@ -1146,7 +1146,7 @@ The each bit of [=recon_gain_flags=] indicates the presence of [=recon_gain=] ap
 
 <dfn noexport>n(i)</dfn> shall indicate the number of bits for recon_gain_flag(i). It shall be 7 or 12 as depicted in the about figure. Where, i = 0, 1, ..., [=num_layers=] - 1.
 
-<dfn noexport>recon_gain</dfn> shall indicate the gain value to be applied to the channel, which is indicated by [=recon_gain_flags=], after decoding of the following associated frames.
+<dfn noexport>recon_gain</dfn> shall indicate the gain value to be applied to the channel, which is indicated by [=recon_gain_flags=], after decoding of the associated frames and demixing operation.
 
 ### Mix Target Layout Syntax and Semantics ### {#syntax-mix-target-layout}
 

--- a/index.bs
+++ b/index.bs
@@ -1146,7 +1146,7 @@ The each bit of [=recon_gain_flags=] indicates the presence of [=recon_gain=] ap
 
 <dfn noexport>n(i)</dfn> shall indicate the number of bits for recon_gain_flag(i). It shall be 7 or 12 as depicted in the about figure. Where, i = 0, 1, ..., [=num_layers=] - 1.
 
-<dfn noexport>recon_gain</dfn> shall indicate the gain value to be applied to the channel, which is indicated by [=recon_gain_flags=], after decoding of the associated frames and demixing operation.
+<dfn noexport>recon_gain</dfn> shall indicate the gain value to be applied to the channel, which is indicated by [=recon_gain_flags=], after decoding of the associated frames and demixing operation. Where, the channel is indicated by recon_gain_flags. Detailed operation by using this value is specified in [[#processing-scalablechannelaudio-recongain]].
 
 ### Mix Target Layout Syntax and Semantics ### {#syntax-mix-target-layout}
 

--- a/index.bs
+++ b/index.bs
@@ -1144,7 +1144,7 @@ The each bit of [=recon_gain_flags=] indicates the presence of [=recon_gain=] ap
  - 0: It shall indicate that no [=recon_gain=] presents for the channel.
  - 1: It shall indicate that [=recon_gain=] presents for the channel.
 
-<dfn noexport>n(i)</dfn> shall indicate the number of bits for recon_gain_flag(i). It shall be 7 or 12 as depicted in the about figure. Where, i = 0, 1, ..., [=num_layers=] - 1.
+<dfn noexport>n(i)</dfn> shall indicate the number of bits for recon_gain_flag(i). It shall be 7 or 12 as depicted in the above figure. Where, i = 0, 1, ..., [=num_layers=] - 1.
 
 <dfn noexport>recon_gain</dfn> shall indicate the gain value to be applied to the channel, which is indicated by [=recon_gain_flags=], after decoding of the associated frames and demixing operation. Where, the channel is indicated by recon_gain_flags. Detailed operation by using this value is specified in [[#processing-scalablechannelaudio-recongain]].
 


### PR DESCRIPTION
Define n(i) for recon_gain_flag
Add definition for values of recon_gain_flags


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/pull/203.html" title="Last updated on Dec 1, 2022, 3:09 AM UTC (f27c4dc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/203/678eed5...f27c4dc.html" title="Last updated on Dec 1, 2022, 3:09 AM UTC (f27c4dc)">Diff</a>