### PR TITLE
Minor tweaks for selecting an input layout for the renderer

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -768,8 +768,6 @@ If one sub-mix of Mix Presentation OBU includes only one single scalable channel
 
 The highest [=loudness_layout=] specified in one sub-mix is the layout which was used for authoring the sub-mix.
 
-ISSUE: Loudness_info in scalable_channel_audio_layer is removed instead.
-
 #### Mix Presentation Annotations Syntax and Semantics #### {#obu-mixpresentation-annotation}
 
 <b>Syntax</b>
@@ -2356,40 +2354,38 @@ An IA sequence may contain more than one mix presentations. The IA parser should
 
 ### Rendering an Audio Element ### {#processing-mixpresentation-rendering}
 
+This specification supports the rendering of either a multichannel or ambisonics audio element to either a target loudspeaker layout or a binaural output. The choice of the renderer to use when processing a mix presentation depends on the input audio element and the playback layout, as defined below and summarized in the following table.
+
 After selecting a Mix Presentation, an audio element should be rendered as follows:
-- If the selected Mix Presentation OBU includes only one single channel-based audio element, do M2M-Rendering (M2M-Rendering: Multichannel to Multichannel Rendering).
-- If the selected Mix Presentation OBU includes only one single scene-based audio element, do A2M-Rendering (A2M-Rendering: Ambisonics to Multichannel Rendering).
-- If the selected Mix Presentation OBU includes multiple audio elements.
-	- If the audio element is channel-based, then it should follow M2M-Rendering.
-	- If the audio elemetn is scene-based, then it should follow A2M-Rendering.
+- If the audio element is a channel-based element, apply M2M-Rendering (M2M-Rendering: Multichannel to Multichannel Rendering).
+- If the audio element is a scene-based audio element, apply A2M-Rendering (A2M-Rendering: Ambisonics to Multichannel Rendering).
 	
 For M2M-Rendering,
-- The input layout of the IA renderer
-	- If num_layer = 1, use the [=loudspeaker_layout=] of the audio element.
-	- Else, use the layout that matches the playback layout, or is the next highest available layout.
-- The IA render
+- The input layout of the IA renderer is set as follows:
+	- If [=num_layers=] = 1, use the [=loudspeaker_layout=] of the audio element.
+	- Else, if there is a [=loudness_layout=] that matches the playback layout, use it.
+	- Else, use the highest available layout from all available [=loudspeaker_layout=] and [=loudness_layout=].
+- The output layout of the IA renderer is set to the playback layout.
+- The IA renderer used is selected according to the following rules:
 	- If the playback layout matches a [=loudspeaker_layout=] which can be generated from the highest loudspeaker layout of the audio element according to [[#iacgeneration-scalablechannelaudio-channellayoutgenerationrule]], use demixing_info_parameter_data().
 		- If demixing_info_parameter_data() is not delivered, use EAR Direct Speakers renderer ([[!ITU2127-0]]).
 	- Else if the playback layout complies with loudspeaker layouts supported by [[!ITU2051-3]], use EAR Direct Speakers renderer ([[!ITU2127-0]]).
 	- Else, use implementation-specific renderer.
-- The output of the IA render: the playback layout
  
 For A2M-Rendering,
-- The input layout of the IA renderer: Ambisonics
-- The IA render
+- The input layout of the IA renderer is set to Ambisonics.
+- The output layout of the IA renderer is set to the playback layout.
+- The IA renderer used is selected according to the following rules:
 	- If the playback layout complies with loudspeaker layouts supported by [[!ITU2051-3]], use EAR HOA renderer ([[!ITU2127-0]]).
 	- Else, use implementation-specific renderer.
-		- If there is no implementation-specific Ambisonics renderer, use libear to render to the next highest BS2051 layout compared to the playback layout, and then downmix using implementation-specific renderer.
-- The output of the IA render: the playback layout
-
-This specification supports the rendering of either a multichannel or ambisonics audio element to either a target loudspeaker layout or a binaural output. The choice of the renderer to use when processing a mix presentation depends on the input audio element and the playback layout, as defined in the table below.
+		- If there is no implementation-specific Ambisonics renderer, use the EAR HOA renderer to render to the next highest [[!ITU2051-3]] layout compared to the playback layout, and then downmix using implementation-specific renderer.
 
 <table class="def">
 <tr>
   <th>audio_element_type</th><th>Playback layout</th><th>Renderer to use</th>
 </tr>
 <tr>
-  <td>CHANNEL_BASED</td><td>Loudspeaker layouts supported by [[!ITU2051-3]]</td><td>EAR Direct Speakers renderer ([[!ITU2127-0]]).</td>
+  <td>CHANNEL_BASED</td><td>Loudspeaker layouts supported by [[!ITU2051-3]]</td><td>If there is a playback layout that can be generated from the input layout according to [[#iacgeneration-scalablechannelaudio-channellayoutgenerationrule]], use the provided demixing_info_parameter_data().<br><br> If demixing_info_parameter_data() is not provided, use the EAR Direct Speakers renderer ([[!ITU2127-0]]).</td>
 </tr>
 <tr>
   <td>CHANNEL_BASED</td><td>Loudspeaker layouts not supported by [[!ITU2051-3]]</td><td>Implementation-specific loudspeaker renderer.</td>
@@ -2398,7 +2394,7 @@ This specification supports the rendering of either a multichannel or ambisonics
   <td>SCENE_BASED</td><td>Loudspeaker layouts supported by [[!ITU2051-3]]</td><td>EAR HOA renderer ([[!ITU2127-0]]).</td>
 </tr>
 <tr>
-  <td>SCENE_BASED</td><td>Loudspeaker layouts not supported by [[!ITU2051-3]]</td><td>Implementation-specific Ambisonics renderer.<br><br>If an implementation-specific Ambisonics renderer is not available, the EAR HOA renderer may be used to render the Ambisonics audio element to the an [[!ITU2051-3]] layout than the output loudspeaker layout, and then downmixed using the implementation-specific loudspeaker renderer.</td>
+  <td>SCENE_BASED</td><td>Loudspeaker layouts not supported by [[!ITU2051-3]]</td><td>Implementation-specific Ambisonics renderer.<br><br>If an implementation-specific Ambisonics renderer is not available, the EAR HOA renderer may be used to render the Ambisonics audio element to the next highest [[!ITU2051-3]] layout compared to the output loudspeaker layout, and then downmixed using the implementation-specific loudspeaker renderer.</td>
 </tr>
 <tr>
   <td>CHANNEL_BASED</td><td>Binaural</td><td>// TODO</td>
@@ -2440,7 +2436,7 @@ Each audio element is processed individually before mixing as follows:
 1. Render to the playback layout.
 2. If all audio elements do not have a common sample rate, re-sample to 48 kHz.
 3. If all audio elements do not have a common bit-depth, convert to a common bit-depth. This specification recommends using 16 bits.
-4. If [=loudness_layout=] matches with the playback layout, apply any per-element processing according to [=element_mix_config()=]. Otherwise, apply any per-element processing according to implementation-specific element_mix.
+4. If [=loudness_layout=] matches with the playback layout, apply any per-element processing according to [=element_mix_config()=].
 
 The rendered and processed audio elements are then summed, and then apply [=output_mix_config()=] to generate one sub-mixed audio signal. If there are more than one sub-mixes, the output of each sub-mix is further summed to generate the final mixed audio signal.
 


### PR DESCRIPTION
- Clarify that the highest layout should be chosen
- Editorial tweaks


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jan 18, 2023, 9:04 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2FAOMediaCodec%2Fiamf%2Fb2d2ed46a70d92a4751b75c52751d8b618766526%2Findex.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 2.
Your document appears to use spaces to indent, but line 372 starts with tabs.
Your document appears to use spaces to indent, but line 373 starts with tabs.
Your document appears to use spaces to indent, but line 374 starts with tabs.
Your document appears to use spaces to indent, but line 375 starts with tabs.
Your document appears to use spaces to indent, but line 376 starts with tabs.
Your document appears to use spaces to indent, but line 377 starts with tabs.
Your document appears to use spaces to indent, but line 378 starts with tabs.
Your document appears to use spaces to indent, but line 379 starts with tabs.
Your document appears to use spaces to indent, but line 380 starts with tabs.
Your document appears to use spaces to indent, but line 381 starts with tabs.
Your document appears to use spaces to indent, but line 382 starts with tabs.
Your document appears to use spaces to indent, but line 384 starts with tabs.
Your document appears to use spaces to indent, but line 385 starts with tabs.
Your document appears to use spaces to indent, but line 906 starts with tabs.
Your document appears to use spaces to indent, but line 907 starts with tabs.
Your document appears to use spaces to indent, but line 908 starts with tabs.
Your document appears to use spaces to indent, but line 1674 starts with tabs.
Your document appears to use spaces to indent, but line 1675 starts with tabs.
Your document appears to use spaces to indent, but line 1676 starts with tabs.
Your document appears to use spaces to indent, but line 1677 starts with tabs.
Your document appears to use spaces to indent, but line 1678 starts with tabs.
Your document appears to use spaces to indent, but line 1679 starts with tabs.
Your document appears to use spaces to indent, but line 1730 starts with tabs.
Your document appears to use spaces to indent, but line 1731 starts with tabs.
Your document appears to use spaces to indent, but line 1755 starts with tabs.
Your document appears to use spaces to indent, but line 1756 starts with tabs.
Your document appears to use spaces to indent, but line 1757 starts with tabs.
Your document appears to use spaces to indent, but line 1963 starts with tabs.
Your document appears to use spaces to indent, but line 1964 starts with tabs.
Your document appears to use spaces to indent, but line 1965 starts with tabs.
Your document appears to use spaces to indent, but line 1969 starts with tabs.
Your document appears to use spaces to indent, but line 1970 starts with tabs.
Your document appears to use spaces to indent, but line 1971 starts with tabs.
Your document appears to use spaces to indent, but line 1973 starts with tabs.
Your document appears to use spaces to indent, but line 1974 starts with tabs.
Your document appears to use spaces to indent, but line 1975 starts with tabs.
Your document appears to use spaces to indent, but line 1976 starts with tabs.
Your document appears to use spaces to indent, but line 2119 starts with tabs.
Your document appears to use spaces to indent, but line 2120 starts with tabs.
Your document appears to use spaces to indent, but line 2122 starts with tabs.
Your document appears to use spaces to indent, but line 2123 starts with tabs.
Your document appears to use spaces to indent, but line 2154 starts with tabs.
Your document appears to use spaces to indent, but line 2155 starts with tabs.
Your document appears to use spaces to indent, but line 2156 starts with tabs.
Your document appears to use spaces to indent, but line 2157 starts with tabs.
Your document appears to use spaces to indent, but line 2160 starts with tabs.
Your document appears to use spaces to indent, but line 2161 starts with tabs.
Your document appears to use spaces to indent, but line 2162 starts with tabs.
Your document appears to use spaces to indent, but line 2167 starts with tabs.
Your document appears to use spaces to indent, but line 2168 starts with tabs.
Your document appears to use spaces to indent, but line 2184 starts with tabs.
Your document appears to use spaces to indent, but line 2196 starts with tabs.
Your document appears to use spaces to indent, but line 2197 starts with tabs.
Your document appears to use spaces to indent, but line 2199 starts with tabs.
Your document appears to use spaces to indent, but line 2200 starts with tabs.
Your document appears to use spaces to indent, but line 2201 starts with tabs.
Your document appears to use spaces to indent, but line 2211 starts with tabs.
Your document appears to use spaces to indent, but line 2231 starts with tabs.
Your document appears to use spaces to indent, but line 2233 starts with tabs.
Your document appears to use spaces to indent, but line 2234 starts with tabs.
Your document appears to use spaces to indent, but line 2235 starts with tabs.
Your document appears to use spaces to indent, but line 2236 starts with tabs.
Your document appears to use spaces to indent, but line 2238 starts with tabs.
Your document appears to use spaces to indent, but line 2239 starts with tabs.
Your document appears to use spaces to indent, but line 2240 starts with tabs.
Your document appears to use spaces to indent, but line 2264 starts with tabs.
Your document appears to use spaces to indent, but line 2265 starts with tabs.
Your document appears to use spaces to indent, but line 2266 starts with tabs.
Your document appears to use spaces to indent, but line 2267 starts with tabs.
Your document appears to use spaces to indent, but line 2269 starts with tabs.
Your document appears to use spaces to indent, but line 2270 starts with tabs.
Your document appears to use spaces to indent, but line 2319 starts with tabs.
Your document appears to use spaces to indent, but line 2320 starts with tabs.
Your document appears to use spaces to indent, but line 2321 starts with tabs.
Your document appears to use spaces to indent, but line 2322 starts with tabs.
Your document appears to use spaces to indent, but line 2323 starts with tabs.
Your document appears to use spaces to indent, but line 2324 starts with tabs.
Your document appears to use spaces to indent, but line 2325 starts with tabs.
Your document appears to use spaces to indent, but line 2348 starts with tabs.
Your document appears to use spaces to indent, but line 2349 starts with tabs.
Your document appears to use spaces to indent, but line 2350 starts with tabs.
Your document appears to use spaces to indent, but line 2351 starts with tabs.
Your document appears to use spaces to indent, but line 2352 starts with tabs.
Your document appears to use spaces to indent, but line 2353 starts with tabs.
Your document appears to use spaces to indent, but line 2362 starts with tabs.
Your document appears to use spaces to indent, but line 2365 starts with tabs.
Your document appears to use spaces to indent, but line 2366 starts with tabs.
Your document appears to use spaces to indent, but line 2367 starts with tabs.
Your document appears to use spaces to indent, but line 2370 starts with tabs.
Your document appears to use spaces to indent, but line 2371 starts with tabs.
Your document appears to use spaces to indent, but line 2372 starts with tabs.
Your document appears to use spaces to indent, but line 2373 starts with tabs.
Your document appears to use spaces to indent, but line 2379 starts with tabs.
Your document appears to use spaces to indent, but line 2380 starts with tabs.
Your document appears to use spaces to indent, but line 2381 starts with tabs.
Your document appears to use spaces to indent, but line 2516 starts with tabs.
Your document appears to use spaces to indent, but line 2537 starts with tabs.
Your document appears to use spaces to indent, but line 2538 starts with tabs.
Your document appears to use spaces to indent, but line 2539 starts with tabs.
Your document appears to use spaces to indent, but line 2540 starts with tabs.
Your document appears to use spaces to indent, but line 2541 starts with tabs.
Your document appears to use spaces to indent, but line 2542 starts with tabs.
Your document appears to use spaces to indent, but line 2543 starts with tabs.
Your document appears to use spaces to indent, but line 2545 starts with tabs.
Your document appears to use spaces to indent, but line 2546 starts with tabs.
Your document appears to use spaces to indent, but line 2547 starts with tabs.
Your document appears to use spaces to indent, but line 2548 starts with tabs.
Your document appears to use spaces to indent, but line 2550 starts with tabs.
Your document appears to use spaces to indent, but line 2558 starts with tabs.
Your document appears to use spaces to indent, but line 2559 starts with tabs.
Your document appears to use spaces to indent, but line 2560 starts with tabs.
Your document appears to use spaces to indent, but line 2561 starts with tabs.
Your document appears to use spaces to indent, but line 2562 starts with tabs.
Your document appears to use spaces to indent, but line 2563 starts with tabs.
Your document appears to use spaces to indent, but line 2564 starts with tabs.
Your document appears to use spaces to indent, but line 2565 starts with tabs.
Your document appears to use spaces to indent, but line 2566 starts with tabs.
Your document appears to use spaces to indent, but line 2572 starts with tabs.
Your document appears to use spaces to indent, but line 2573 starts with tabs.
Your document appears to use spaces to indent, but line 2574 starts with tabs.
Your document appears to use spaces to indent, but line 2575 starts with tabs.
Your document appears to use spaces to indent, but line 2576 starts with tabs.
Your document appears to use spaces to indent, but line 2577 starts with tabs.
Your document appears to use spaces to indent, but line 2580 starts with tabs.
Your document appears to use spaces to indent, but line 2581 starts with tabs.
Your document appears to use spaces to indent, but line 2587 starts with tabs.
Your document appears to use spaces to indent, but line 2588 starts with tabs.
Your document appears to use spaces to indent, but line 2589 starts with tabs.
Your document appears to use spaces to indent, but line 2590 starts with tabs.
Your document appears to use spaces to indent, but line 2591 starts with tabs.
Your document appears to use spaces to indent, but line 2592 starts with tabs.
Your document appears to use spaces to indent, but line 2593 starts with tabs.
Your document appears to use spaces to indent, but line 2594 starts with tabs.
Your document appears to use spaces to indent, but line 2595 starts with tabs.
Your document appears to use spaces to indent, but line 2596 starts with tabs.
Your document appears to use spaces to indent, but line 2597 starts with tabs.
Your document appears to use spaces to indent, but line 2598 starts with tabs.
Your document appears to use spaces to indent, but line 2599 starts with tabs.
Your document appears to use spaces to indent, but line 2600 starts with tabs.
Your document appears to use spaces to indent, but line 2601 starts with tabs.
Your document appears to use spaces to indent, but line 2602 starts with tabs.
Your document appears to use spaces to indent, but line 2603 starts with tabs.
Your document appears to use spaces to indent, but line 2604 starts with tabs.
Your document appears to use spaces to indent, but line 2605 starts with tabs.
Your document appears to use spaces to indent, but line 2606 starts with tabs.
Your document appears to use spaces to indent, but line 2607 starts with tabs.
Your document appears to use spaces to indent, but line 2608 starts with tabs.
Your document appears to use spaces to indent, but line 2609 starts with tabs.
Your document appears to use spaces to indent, but line 2610 starts with tabs.
Your document appears to use spaces to indent, but line 2611 starts with tabs.
Your document appears to use spaces to indent, but line 2613 starts with tabs.
Your document appears to use spaces to indent, but line 2614 starts with tabs.
Your document appears to use spaces to indent, but line 2619 starts with tabs.
Your document appears to use spaces to indent, but line 2622 starts with tabs.
Your document appears to use spaces to indent, but line 2625 starts with tabs.
Your document appears to use spaces to indent, but line 2629 starts with tabs.
Your document appears to use spaces to indent, but line 2630 starts with tabs.
Your document appears to use spaces to indent, but line 2649 starts with tabs.
Your document appears to use spaces to indent, but line 2650 starts with tabs.
Your document appears to use spaces to indent, but line 2651 starts with tabs.
Your document appears to use spaces to indent, but line 2652 starts with tabs.
Your document appears to use spaces to indent, but line 2653 starts with tabs.
Your document appears to use spaces to indent, but line 2654 starts with tabs.
Your document appears to use spaces to indent, but line 2655 starts with tabs.
Your document appears to use spaces to indent, but line 2657 starts with tabs.
Your document appears to use spaces to indent, but line 2753 starts with tabs.
Your document appears to use spaces to indent, but line 2754 starts with tabs.
Your document appears to use spaces to indent, but line 2755 starts with tabs.
Your document appears to use spaces to indent, but line 2756 starts with tabs.
Your document appears to use spaces to indent, but line 2757 starts with tabs.
Your document appears to use spaces to indent, but line 2758 starts with tabs.
Your document appears to use spaces to indent, but line 2759 starts with tabs.
Your document appears to use spaces to indent, but line 2760 starts with tabs.
Your document appears to use spaces to indent, but line 2761 starts with tabs.
Your document appears to use spaces to indent, but line 2822 starts with tabs.
Your document appears to use spaces to indent, but line 2823 starts with tabs.
Your document appears to use spaces to indent, but line 2825 starts with tabs.
Your document appears to use spaces to indent, but line 2827 starts with tabs.
Your document appears to use spaces to indent, but line 2828 starts with tabs.
Your document appears to use spaces to indent, but line 2829 starts with tabs.
Your document appears to use spaces to indent, but line 2833 starts with tabs.
Your document appears to use spaces to indent, but line 2834 starts with tabs.
Your document appears to use spaces to indent, but line 2836 starts with tabs.
Your document appears to use spaces to indent, but line 2848 starts with tabs.
Your document appears to use spaces to indent, but line 2850 starts with tabs.
Your document appears to use spaces to indent, but line 2852 starts with tabs.
Your document appears to use spaces to indent, but line 2853 starts with tabs.
Your document appears to use spaces to indent, but line 2854 starts with tabs.
Your document appears to use spaces to indent, but line 2859 starts with tabs.
WARNING: The heading 'Annex A: Audio Substream Gaps' needs a manually-specified ID.
WARNING: The heading 'A gap due to packet loss' needs a manually-specified ID.
WARNING: The heading 'A gap between two audio substreams' needs a manually-specified ID.
WARNING: The heading 'A gap within an audio substream' needs a manually-specified ID.
WARNING: Multiple elements have the same ID 'iamfgeneration-postprocessing-drc'.
Deduping, but this ID may not be stable across revisions.
WARNING: At least one &lt;img> doesn't have its size set (&lt;img src="images/Conceptual%20IAC%20Architecture.png">), but given the type of input document, Bikeshed can't figure out what the size should be.
Either set 'width'/'height' manually, or opt out of auto-detection by setting the 'no-autosize' attribute.
LINK ERROR: No 'property' refs found for 'iamf'.
'iamf'
LINK ERROR: No 'property' refs found for 'lpcm'.
'lpcm'
LINK ERROR: No 'dfn' refs found for 'num_audio_elements'.
[=num_audio_elements=]
FATAL ERROR: Couldn't find target document section iacgeneration-scalablechannelaudio-channellayoutgenerationrule:
[[#iacgeneration-scalablechannelaudio-channellayoutgenerationrule]]
 ✘  Did not generate, due to fatal errors
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20AOMediaCodec/iamf%23229.)._
</details>
