### PR TITLE
Update the data as of today

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7,7 +7,7 @@ Editor: Felicia Lim, Google, flim@google.com
 Repository: AOMediaCodec/iamf
 Shortname: iamf
 URL: https://aomediacodec.github.io/iamf/
-Date: 2023-01-09
+Date: 2023-01-17
 Abstract: This document specifies an immersive audio (IA) architecture and model, a standalone IA sequence format and an [[!ISOBMFF]]-based IA container format.
 </pre>
 
@@ -2387,7 +2387,7 @@ For a given x.y.z layout, the next highest layout x'.y'.z' means that x', y' and
   <th>audio_element_type</th><th>Playback layout</th><th>Renderer to use</th>
 </tr>
 <tr>
-  <td>CHANNEL_BASED</td><td>Loudspeaker layouts supported by [[!ITU2051-3]]</td><td>If there is a playback layout that can be generated from the input layout according to [[#iacgeneration-scalablechannelaudio-channellayoutgenerationrule]], use the provided demixing_info_parameter_data().<br><br> If demixing_info_parameter_data() is not provided, use the EAR Direct Speakers renderer ([[!ITU2127-0]]).</td>
+  <td>CHANNEL_BASED</td><td>Loudspeaker layouts supported by [[!ITU2051-3]]</td><td>If there is a playback layout that can be generated from the input layout according to [[#iamfgeneration-scalablechannelaudio-channellayoutgenerationrule]], use the provided demixing_info_parameter_data().<br><br> If demixing_info_parameter_data() is not provided, use the EAR Direct Speakers renderer ([[!ITU2127-0]]).</td>
 </tr>
 <tr>
   <td>CHANNEL_BASED</td><td>Loudspeaker layouts not supported by [[!ITU2051-3]]</td><td>Implementation-specific loudspeaker renderer.</td>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jan 18, 2023, 9:21 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2FAOMediaCodec%2Fiamf%2F77ab8e1ffe00dbe5048c50bf74e63cb41e36fde3%2Findex.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 2.
Your document appears to use spaces to indent, but line 372 starts with tabs.
Your document appears to use spaces to indent, but line 373 starts with tabs.
Your document appears to use spaces to indent, but line 374 starts with tabs.
Your document appears to use spaces to indent, but line 375 starts with tabs.
Your document appears to use spaces to indent, but line 376 starts with tabs.
Your document appears to use spaces to indent, but line 377 starts with tabs.
Your document appears to use spaces to indent, but line 378 starts with tabs.
Your document appears to use spaces to indent, but line 379 starts with tabs.
Your document appears to use spaces to indent, but line 380 starts with tabs.
Your document appears to use spaces to indent, but line 381 starts with tabs.
Your document appears to use spaces to indent, but line 382 starts with tabs.
Your document appears to use spaces to indent, but line 384 starts with tabs.
Your document appears to use spaces to indent, but line 385 starts with tabs.
Your document appears to use spaces to indent, but line 906 starts with tabs.
Your document appears to use spaces to indent, but line 907 starts with tabs.
Your document appears to use spaces to indent, but line 908 starts with tabs.
Your document appears to use spaces to indent, but line 1674 starts with tabs.
Your document appears to use spaces to indent, but line 1675 starts with tabs.
Your document appears to use spaces to indent, but line 1676 starts with tabs.
Your document appears to use spaces to indent, but line 1677 starts with tabs.
Your document appears to use spaces to indent, but line 1678 starts with tabs.
Your document appears to use spaces to indent, but line 1679 starts with tabs.
Your document appears to use spaces to indent, but line 1730 starts with tabs.
Your document appears to use spaces to indent, but line 1731 starts with tabs.
Your document appears to use spaces to indent, but line 1755 starts with tabs.
Your document appears to use spaces to indent, but line 1756 starts with tabs.
Your document appears to use spaces to indent, but line 1757 starts with tabs.
Your document appears to use spaces to indent, but line 1963 starts with tabs.
Your document appears to use spaces to indent, but line 1964 starts with tabs.
Your document appears to use spaces to indent, but line 1965 starts with tabs.
Your document appears to use spaces to indent, but line 1969 starts with tabs.
Your document appears to use spaces to indent, but line 1970 starts with tabs.
Your document appears to use spaces to indent, but line 1971 starts with tabs.
Your document appears to use spaces to indent, but line 1973 starts with tabs.
Your document appears to use spaces to indent, but line 1974 starts with tabs.
Your document appears to use spaces to indent, but line 1975 starts with tabs.
Your document appears to use spaces to indent, but line 1976 starts with tabs.
Your document appears to use spaces to indent, but line 2119 starts with tabs.
Your document appears to use spaces to indent, but line 2120 starts with tabs.
Your document appears to use spaces to indent, but line 2122 starts with tabs.
Your document appears to use spaces to indent, but line 2123 starts with tabs.
Your document appears to use spaces to indent, but line 2154 starts with tabs.
Your document appears to use spaces to indent, but line 2155 starts with tabs.
Your document appears to use spaces to indent, but line 2156 starts with tabs.
Your document appears to use spaces to indent, but line 2157 starts with tabs.
Your document appears to use spaces to indent, but line 2160 starts with tabs.
Your document appears to use spaces to indent, but line 2161 starts with tabs.
Your document appears to use spaces to indent, but line 2162 starts with tabs.
Your document appears to use spaces to indent, but line 2167 starts with tabs.
Your document appears to use spaces to indent, but line 2168 starts with tabs.
Your document appears to use spaces to indent, but line 2184 starts with tabs.
Your document appears to use spaces to indent, but line 2196 starts with tabs.
Your document appears to use spaces to indent, but line 2197 starts with tabs.
Your document appears to use spaces to indent, but line 2199 starts with tabs.
Your document appears to use spaces to indent, but line 2200 starts with tabs.
Your document appears to use spaces to indent, but line 2201 starts with tabs.
Your document appears to use spaces to indent, but line 2211 starts with tabs.
Your document appears to use spaces to indent, but line 2231 starts with tabs.
Your document appears to use spaces to indent, but line 2233 starts with tabs.
Your document appears to use spaces to indent, but line 2234 starts with tabs.
Your document appears to use spaces to indent, but line 2235 starts with tabs.
Your document appears to use spaces to indent, but line 2236 starts with tabs.
Your document appears to use spaces to indent, but line 2238 starts with tabs.
Your document appears to use spaces to indent, but line 2239 starts with tabs.
Your document appears to use spaces to indent, but line 2240 starts with tabs.
Your document appears to use spaces to indent, but line 2264 starts with tabs.
Your document appears to use spaces to indent, but line 2265 starts with tabs.
Your document appears to use spaces to indent, but line 2266 starts with tabs.
Your document appears to use spaces to indent, but line 2267 starts with tabs.
Your document appears to use spaces to indent, but line 2269 starts with tabs.
Your document appears to use spaces to indent, but line 2270 starts with tabs.
Your document appears to use spaces to indent, but line 2319 starts with tabs.
Your document appears to use spaces to indent, but line 2320 starts with tabs.
Your document appears to use spaces to indent, but line 2321 starts with tabs.
Your document appears to use spaces to indent, but line 2322 starts with tabs.
Your document appears to use spaces to indent, but line 2323 starts with tabs.
Your document appears to use spaces to indent, but line 2324 starts with tabs.
Your document appears to use spaces to indent, but line 2325 starts with tabs.
Your document appears to use spaces to indent, but line 2348 starts with tabs.
Your document appears to use spaces to indent, but line 2349 starts with tabs.
Your document appears to use spaces to indent, but line 2350 starts with tabs.
Your document appears to use spaces to indent, but line 2351 starts with tabs.
Your document appears to use spaces to indent, but line 2352 starts with tabs.
Your document appears to use spaces to indent, but line 2353 starts with tabs.
Your document appears to use spaces to indent, but line 2362 starts with tabs.
Your document appears to use spaces to indent, but line 2365 starts with tabs.
Your document appears to use spaces to indent, but line 2366 starts with tabs.
Your document appears to use spaces to indent, but line 2367 starts with tabs.
Your document appears to use spaces to indent, but line 2370 starts with tabs.
Your document appears to use spaces to indent, but line 2371 starts with tabs.
Your document appears to use spaces to indent, but line 2372 starts with tabs.
Your document appears to use spaces to indent, but line 2373 starts with tabs.
Your document appears to use spaces to indent, but line 2379 starts with tabs.
Your document appears to use spaces to indent, but line 2380 starts with tabs.
Your document appears to use spaces to indent, but line 2381 starts with tabs.
Your document appears to use spaces to indent, but line 2516 starts with tabs.
Your document appears to use spaces to indent, but line 2537 starts with tabs.
Your document appears to use spaces to indent, but line 2538 starts with tabs.
Your document appears to use spaces to indent, but line 2539 starts with tabs.
Your document appears to use spaces to indent, but line 2540 starts with tabs.
Your document appears to use spaces to indent, but line 2541 starts with tabs.
Your document appears to use spaces to indent, but line 2542 starts with tabs.
Your document appears to use spaces to indent, but line 2543 starts with tabs.
Your document appears to use spaces to indent, but line 2545 starts with tabs.
Your document appears to use spaces to indent, but line 2546 starts with tabs.
Your document appears to use spaces to indent, but line 2547 starts with tabs.
Your document appears to use spaces to indent, but line 2548 starts with tabs.
Your document appears to use spaces to indent, but line 2550 starts with tabs.
Your document appears to use spaces to indent, but line 2558 starts with tabs.
Your document appears to use spaces to indent, but line 2559 starts with tabs.
Your document appears to use spaces to indent, but line 2560 starts with tabs.
Your document appears to use spaces to indent, but line 2561 starts with tabs.
Your document appears to use spaces to indent, but line 2562 starts with tabs.
Your document appears to use spaces to indent, but line 2563 starts with tabs.
Your document appears to use spaces to indent, but line 2564 starts with tabs.
Your document appears to use spaces to indent, but line 2565 starts with tabs.
Your document appears to use spaces to indent, but line 2566 starts with tabs.
Your document appears to use spaces to indent, but line 2572 starts with tabs.
Your document appears to use spaces to indent, but line 2573 starts with tabs.
Your document appears to use spaces to indent, but line 2574 starts with tabs.
Your document appears to use spaces to indent, but line 2575 starts with tabs.
Your document appears to use spaces to indent, but line 2576 starts with tabs.
Your document appears to use spaces to indent, but line 2577 starts with tabs.
Your document appears to use spaces to indent, but line 2580 starts with tabs.
Your document appears to use spaces to indent, but line 2581 starts with tabs.
Your document appears to use spaces to indent, but line 2587 starts with tabs.
Your document appears to use spaces to indent, but line 2588 starts with tabs.
Your document appears to use spaces to indent, but line 2589 starts with tabs.
Your document appears to use spaces to indent, but line 2590 starts with tabs.
Your document appears to use spaces to indent, but line 2591 starts with tabs.
Your document appears to use spaces to indent, but line 2592 starts with tabs.
Your document appears to use spaces to indent, but line 2593 starts with tabs.
Your document appears to use spaces to indent, but line 2594 starts with tabs.
Your document appears to use spaces to indent, but line 2595 starts with tabs.
Your document appears to use spaces to indent, but line 2596 starts with tabs.
Your document appears to use spaces to indent, but line 2597 starts with tabs.
Your document appears to use spaces to indent, but line 2598 starts with tabs.
Your document appears to use spaces to indent, but line 2599 starts with tabs.
Your document appears to use spaces to indent, but line 2600 starts with tabs.
Your document appears to use spaces to indent, but line 2601 starts with tabs.
Your document appears to use spaces to indent, but line 2602 starts with tabs.
Your document appears to use spaces to indent, but line 2603 starts with tabs.
Your document appears to use spaces to indent, but line 2604 starts with tabs.
Your document appears to use spaces to indent, but line 2605 starts with tabs.
Your document appears to use spaces to indent, but line 2606 starts with tabs.
Your document appears to use spaces to indent, but line 2607 starts with tabs.
Your document appears to use spaces to indent, but line 2608 starts with tabs.
Your document appears to use spaces to indent, but line 2609 starts with tabs.
Your document appears to use spaces to indent, but line 2610 starts with tabs.
Your document appears to use spaces to indent, but line 2611 starts with tabs.
Your document appears to use spaces to indent, but line 2613 starts with tabs.
Your document appears to use spaces to indent, but line 2614 starts with tabs.
Your document appears to use spaces to indent, but line 2619 starts with tabs.
Your document appears to use spaces to indent, but line 2622 starts with tabs.
Your document appears to use spaces to indent, but line 2625 starts with tabs.
Your document appears to use spaces to indent, but line 2629 starts with tabs.
Your document appears to use spaces to indent, but line 2630 starts with tabs.
Your document appears to use spaces to indent, but line 2649 starts with tabs.
Your document appears to use spaces to indent, but line 2650 starts with tabs.
Your document appears to use spaces to indent, but line 2651 starts with tabs.
Your document appears to use spaces to indent, but line 2652 starts with tabs.
Your document appears to use spaces to indent, but line 2653 starts with tabs.
Your document appears to use spaces to indent, but line 2654 starts with tabs.
Your document appears to use spaces to indent, but line 2655 starts with tabs.
Your document appears to use spaces to indent, but line 2657 starts with tabs.
Your document appears to use spaces to indent, but line 2753 starts with tabs.
Your document appears to use spaces to indent, but line 2754 starts with tabs.
Your document appears to use spaces to indent, but line 2755 starts with tabs.
Your document appears to use spaces to indent, but line 2756 starts with tabs.
Your document appears to use spaces to indent, but line 2757 starts with tabs.
Your document appears to use spaces to indent, but line 2758 starts with tabs.
Your document appears to use spaces to indent, but line 2759 starts with tabs.
Your document appears to use spaces to indent, but line 2760 starts with tabs.
Your document appears to use spaces to indent, but line 2761 starts with tabs.
Your document appears to use spaces to indent, but line 2822 starts with tabs.
Your document appears to use spaces to indent, but line 2823 starts with tabs.
Your document appears to use spaces to indent, but line 2825 starts with tabs.
Your document appears to use spaces to indent, but line 2827 starts with tabs.
Your document appears to use spaces to indent, but line 2828 starts with tabs.
Your document appears to use spaces to indent, but line 2829 starts with tabs.
Your document appears to use spaces to indent, but line 2833 starts with tabs.
Your document appears to use spaces to indent, but line 2834 starts with tabs.
Your document appears to use spaces to indent, but line 2836 starts with tabs.
Your document appears to use spaces to indent, but line 2848 starts with tabs.
Your document appears to use spaces to indent, but line 2850 starts with tabs.
Your document appears to use spaces to indent, but line 2852 starts with tabs.
Your document appears to use spaces to indent, but line 2853 starts with tabs.
Your document appears to use spaces to indent, but line 2854 starts with tabs.
Your document appears to use spaces to indent, but line 2859 starts with tabs.
WARNING: The heading 'A gap due to packet loss' needs a manually-specified ID.
WARNING: The heading 'A gap between two audio substreams' needs a manually-specified ID.
WARNING: The heading 'A gap within an audio substream' needs a manually-specified ID.
WARNING: The heading 'Annex A: Audio Substream Gaps' needs a manually-specified ID.
WARNING: Multiple elements have the same ID 'iamfgeneration-postprocessing-drc'.
Deduping, but this ID may not be stable across revisions.
WARNING: At least one &lt;img> doesn't have its size set (&lt;img src="images/Conceptual%20IAC%20Architecture.png">), but given the type of input document, Bikeshed can't figure out what the size should be.
Either set 'width'/'height' manually, or opt out of auto-detection by setting the 'no-autosize' attribute.
LINK ERROR: No 'property' refs found for 'iamf'.
'iamf'
LINK ERROR: No 'property' refs found for 'lpcm'.
'lpcm'
LINK ERROR: No 'dfn' refs found for 'num_audio_elements'.
[=num_audio_elements=]
FATAL ERROR: Couldn't find target document section iacgeneration-scalablechannelaudio-channellayoutgenerationrule:
[[#iacgeneration-scalablechannelaudio-channellayoutgenerationrule]]
 ✘  Did not generate, due to fatal errors
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20AOMediaCodec/iamf%23238.)._
</details>
