### PR TITLE
Fix #233

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -555,11 +555,7 @@ This section specifies the OBU payload of OBU_IA_Codec_Config.
 
 ```
 class codec_config_obu() {
-  leb128() codec_config_id;
-  leb128() num_audio_elements;
-  for (i = 0; i < num_audio_elements; i++) {
-    leb128() audio_element_id;
-  }
+  leb128() codec_config_id;  
   codec_config();
 
 }
@@ -576,10 +572,6 @@ class codec_config() {
 <b>Semantics</b>
 
 <dfn noexport>codec_config_id</dfn> shall indicate a unique ID in an IA sequence for a given codec config.
-
-<dfn value noexport for="codec_config_obu()">num_audio_elements</dfn> shall specify the number of audio elements that refer to this codec config.
-
-<dfn value noexport for="codec_config_obu()">audio_element_id</dfn> shall specify the unique ID associated with the specific audio element that refers to this codec config.
 
 <dfn noexport>codec_id</dfn> shall be a ‘four-character code’ (4CC) to identify the codec used to generate the audio substreams. It shall be 'opus' for IAMF-OPUS, 'mp4a' for IAMF-AAC-LC, 'fLaC' for IAMF-FLAC and 'lpcm' for IAMF-LPCM.
 
@@ -607,6 +599,8 @@ class audio_element_obu() {
   leb128() audio_element_id;
   unsigned int (3) audio_element_type;
   unsigned int (5) reserved;
+  
+  leb128() codec_config_id;  
 
   leb128() num_substreams;
   for (i = 0; i < num_substreams; i++) {
@@ -645,7 +639,7 @@ class ReconGainParamDefinition() extends ParamDefinition() {
 
 <b>Semantics</b>
 
-<dfn value noexport for="audio_element_obu()">audio_element_id</dfn> shall indicate a unique ID in an IA sequence for a given audio element. A Codec Config OBU that refers to that audio element shall use the same value for its [=audio_element_id=] field.
+<dfn noexport>audio_element_id</dfn> shall indicate a unique ID in an IA sequence for a given audio element.
 
 <dfn noexport>audio_element_type</dfn> shall specify the audio representation of this audio element which is constructed from one or more audio substreams.
 
@@ -656,9 +650,11 @@ audio_element_type: The type of audio representation.
   2~7   : Reserved
 </pre>
 
+<dfn value noexport for="audio_element_obu()">codec_config_id</dfn> shall indicate the unique ID for the codec config which this audio element refers to.
+
 <dfn noexport>num_substreams</dfn> shall specify the number of audio substreams that are used to reconstruct this audio element.
 
-<dfn noexport>audio_substream_id</dfn> shall specify the unique ID associated with the audio substream that is used to reconstruct this audio element.
+<dfn value noexport for="audio_element_obu()">audio_substream_id</dfn> shall specify the unique ID associated with the audio substream that is used to reconstruct this audio element.
 
 Let a particular ChannelGroup's substream be indexed as [<dfn noexport>c</dfn>, <dfn noexport>n_c</dfn>], where
 - [=c=] = [1, ..., C] is the ChannelGroup index and C is the number of ChannelGroups.
@@ -744,9 +740,9 @@ class mix_presentation_obu() {
 
 <dfn noexport>num_sub_mixes</dfn> specifies the number of sub-mixes.
 
-<dfn value noexport for ="mix_presentation_obu()">num_audio_elements</dfn> shall specify the number of audio elements that are used in this mix presentation to generate the final output audio signal for playback.
+<dfn noexport>num_audio_elements</dfn> shall specify the number of audio elements that are used in this mix presentation to generate the final output audio signal for playback.
 
-<dfn noexport>audio_element_id</dfn> shall indicate the unique ID associated with a specific audio element that is used in this mix presentation.
+<dfn value noexport for ="mix_presentation_obu()">audio_element_id</dfn> shall indicate the unique ID associated with a specific audio element that is used in this mix presentation.
 
 <dfn noexport>rendering_config()</dfn> is a class that provides the metadata required for rendering the referenced audio element. 
 
@@ -887,7 +883,7 @@ class parameter_block_obu() {
 
 <b>Semantics</b>
 
-<dfn value noexport for="parameter_block_obu()">parameter_id</dfn> shall indicate the unique ID that is associated with a specific parameter definition. All parameter blocks that provide data for that parameter definition shall have the same parameter_id.
+<dfn noexport>parameter_id</dfn> shall indicate the unique ID that is associated with a specific parameter definition. All parameter blocks that provide data for that parameter definition shall have the same parameter_id.
 
 <dfn noexport>duration</dfn> shall specify the duration for which this parameter block is valid and applicable. 
 
@@ -968,7 +964,9 @@ abstract class ParamDefinition() {
 
 This section specifies OBU payloads of OBU_IA_Audio_Frame and OBU_IA_Audio_Frame_ID0 to OBU_IA_Audio_Frame_ID21. 
 
-The first 22 audio substreams in an IA sequence may use the OBU types OBU_IA_Audio_Frame_ID0 to OBU_IA_Audio_Frame_ID21, which have predefined audio substream IDs associated with them. This avoids the need to manually specify an audio_substream_id.
+The first 22 audio substreams in an IA sequence may use the OBU types OBU_IA_Audio_Frame_ID0 to OBU_IA_Audio_Frame_ID21, which have predefined audio substream IDs associated with them. This avoids the need to manually specify an [=audio_substream_id=].
+
+[=audio_substream_id=] = 0 to [=audio_substream_id=] = 21 shall be assigned to Audio Frame OBUs with the OBU types OBU_IA_Audio_Frame_ID0 to OBU_IA_Audio_Frame_ID21, respectively. 
 
 <b>Syntax</b>
 
@@ -987,7 +985,7 @@ class audio_frame_obu(audio_substream_id) {
 
 <b>Semantics</b>
 
-<dfn value noexport for="audio_frame_obu_with_no_id()">audio_substream_id</dfn> shall indicate a unique ID in an IA sequence for a given substream. All Audio Frame OBUs of the same substream shall have the same audio_substream_id.
+<dfn noexport>audio_substream_id</dfn> shall indicate a unique ID in an IA sequence for a given substream. All Audio Frame OBUs of the same substream shall have the same audio_substream_id.
 
 This value must be greater or equal to 22, in order to avoid collision with the reserved IDs for the OBU types OBU_IA_Audio_Frame_ID0 to OBU_IA_Audio_Frame_ID21.
 
@@ -2820,20 +2818,20 @@ Step1: Descriptor OBUs are generated as follows:
 - Magic Code OBU: get the larger version field and the larger profile version field, respectively.
 - Codec Config OBU
 	- take just one codec_id and codec_config()
-	- update num_audio_elements and audio_element_id
-- Mix Presentation OBUs: just take all of them and generate new ones which are used for mixing of multiple audio elements if needed except following:
-	- [=audio_element_id=]s are updated to be aligned according to Codec Config OBU.
 - Audio Element OBUs: just take all of them except followings:
-	- [=audio_element_id=]s are updated to be aligned according to Mix Presentation OBUs.
+	- codec_config_id in each Audio Element OBU is updated to indicate [=codec_config_id=] specified in the taken Codec Config OBU.
+	- [=audio_element_id=]s are updated to be unique in all of Audio Element OBUs.
 	- [=audio_substream_id=]s are updated to be unique in all of Audio Element OBUs. 
-	- {{"audio_element_obu()"/parameter_id]s are updated to be unique in all of Audio Element OBUs.
+	- parameter_ids in Audio Element OBUs are updated to be unique in all of Audio Element OBUs.
+- Mix Presentation OBUs: just take all of them and generate new ones which are used for mixing of multiple audio elements if needed except following:
+	- audio_element_ids in each Mix Presentation OBU are updated to indicate the [=audio_element_id=]s specified in Audio Element OBUs.
 
 Step2: ith temporal unit is generated as follows:
 - Just take all of temporal units for ith frames from each audio element and keep the order of temporal units as the order of audio element OBUs in descriptor OBUs except following:
-	- [=obu_type=]s are updated to be aligned according to [=audio_element_id=]s specified in Audio Element OBUs.
-	- {{"parameter_block_obu()"/parameter_id]s in Parameter Block OBUs are updated to be aligned according to {{"audio_element_obu()"/parameter_id]s in Audio Element OBUs.
+	- [=obu_type=]s are updated to be aligned according to [=audio_substream_id=]s specified in Audio Element OBUs.
+	- [=parameter_id=]s in Parameter Block OBUs are updated to be aligned according to parameter_ids in Audio Element OBUs.
 - Add Sync OBU in front of ith temporal unit if needed.
-	- New Sync OBU is generated based on Sync OBUs of each IA sequence and updated [=audio_substream_id=]s and {{"parameter_block_obu()"/parameter_id]s.
+	- New Sync OBU is generated based on Sync OBUs of each IA sequence and updated [=audio_substream_id=]s and [=parameter_id=]s.
 - It may have the immediately preceding temporal delimiter OBU for each temporal unit.
 
 Step3: Generate IA sequence which starts descriptor OBUs and followed by temporal units in order.
@@ -2844,19 +2842,21 @@ This section provides a way how to generate IA sequence having multiple audio el
 
 Step1: Descriptor OBUs are generated as follows:
 - Magic Code OBU: get the larger version field and the larger profile version field, respectively.
-- Codec Config OBU: if some of multiple Codec Config OBUs are same, then merge multiple Codec Config OBUs into one Codec Config OBU, and take each of the others.
-	- Update [=audio_element_id=]s to be unique in all of Codec Config OBUs.
-- Mix Presentation OBUs: just take all of them and generate ones which are used after mixing of multiple audio elements if needed except following:
-	- [=audio_element_id=]s are updated to be aligned according to Codec Config OBU.
+- Codec Config OBU: just take one Codec Config OBU per [=codec_id=].
 - Audio Element OBUs: just take all of them except followings:
-	- [=audio_element_id=]s are updated to be aligned according to Mix Presentation OBUs.
+	- codec_config_id in each Audio Element OBU is updated to indicate [=codec_config_id=] specified in the taken Codec Config OBU.
+	- [=audio_element_id=]s are updated to be unique in all of Audio Element OBUs.
 	- [=audio_substream_id=]s are updated to be unique in all of Audio Element OBUs. 
-	- {{"audio_element_obu()"/parameter_id]s are updated to be unique in all of Audio Element OBUs.
+	- parameter_ids in Audio Element OBUs are updated to be unique in all of Audio Element OBUs.
+- Mix Presentation OBUs: just take all of them and generate ones which are used after mixing of multiple audio elements if needed except following:
+	- audio_element_ids in each Mix Presentation OBU are updated to indicate the [=audio_element_id=]s specified in Audio Element OBUs.
 
 Step2: Data OBUs are generated as follows:
 - Place Temporal Units from multiple audio elements in timing order.
+	- [=obu_type=]s are updated to be aligned according to [=audio_substream_id=]s specified in Audio Element OBUs.
+	- [=parameter_id=]s in Parameter Block OBUs are updated to be aligned according to parameter_ids in Audio Element OBUs.
 - Add Sync OBU in front of Temporal Unit, frequently.
-	- New Sync OBU is generated based on Sync OBUs from each IA sequence and updated [=audio_substream_id=]s and {{"parameter_block_obu()"/parameter_id]s.
+	- New Sync OBU is generated based on Sync OBUs from each IA sequence and updated [=audio_substream_id=]s and [=parameter_id=]s.
 - It may have the immediately preceding temporal delimiter OBU for each audio element,
 
 Step3: Generate IA sequence which starts descriptor OBUs and followed by Temporal Units in order.


### PR DESCRIPTION
Updated Codec Config and Audio Element OBUs.
Also, updated other parts caused by this update.
And, fixed bugs and made clarification which were found during resolving the issue.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jan 19, 2023, 2:01 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2FAOMediaCodec%2Fiamf%2Fac4366832f152ff64aaa38cdf05b6196e5e12b14%2Findex.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 2.
FATAL ERROR: Couldn't open the input file 'https://raw.githubusercontent.com/AOMediaCodec/iamf/ac4366832f152ff64aaa38cdf05b6196e5e12b14/index.bs'.
 ✘  Did not generate, due to fatal errors
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20AOMediaCodec/iamf%23239.)._
</details>
