### PR TITLE
Fix #242: Clarify Codec_ID for OPUS

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1654,6 +1654,8 @@ For legacy codecs, Decoder_Config() shall be exactly the same information as the
 
 ### IAMF-OPUS Specific ### {#iamf-opus-specific}
 
+[=Codec_ID=] shall be 'opus'.
+
 Codec_Specific_Info for IAMF-OPUS shall conform to [=ID Header=] with [=ChannelMappingFamily=] = 0 of [[!RFC7845]] with following constraints:
 - [=Channel Count=] should be set to 2.
 - [=Output Gain=] shall not be used. In other words, it shall be set to 0dB.
@@ -2141,7 +2143,7 @@ For example, for this version of the specification
 
 This section provides a guideline for IAMF parser to reconstruct IA sequences from IAMF file.
 
-When IAMF parser feeds the reconstructed IA sequences to IAMF-OBU parser, descriptor OBUs shall be placed at the first and followed by Temoral Units.
+When IAMF parser feeds the reconstructed IA sequences to IAMF-OBU parser, descriptor OBUs shall be placed at the first and followed by Temporal Units.
 
 Below figure shows the mirroring process of the encapsulation scheme of IA sequence specified in [[#isobmff]].
 


### PR DESCRIPTION
Fixes #242 plus an editorial typo.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jwcullen/iamf/pull/243.html" title="Last updated on Jan 24, 2023, 7:48 PM UTC (4a93d0f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/243/ac43668...jwcullen:4a93d0f.html" title="Last updated on Jan 24, 2023, 7:48 PM UTC (4a93d0f)">Diff</a>