### PR TITLE
Clarify how the Bezier params should be applied to audio samples.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -897,7 +897,7 @@ Audio Element OBU and/or Mix Presentation OBU is mapping a parameter_id to the p
 
 <dfn noexport>segment_interval</dfn> shall specify the interval for the given segment.
 
-Each value of [=duration=], [=constant_segment_interval=] and [=segment_interval=] shall be expressed as the number of ticks at the rate indicated by the time base specified in the corresponding parameter definition.
+Each value of [=duration=], [=constant_segment_interval=] and [=segment_interval=] shall be expressed as the number of ticks at the [=parameter_rate=] specified in the corresponding parameter definition.
 - When it defines <dfn noexport>D</dfn> = the value of [=duration=], <dfn noexport>NS</dfn> = the value of [=num_segments=], <dfn noexport>CSI</dfn> = the value of [=constant_segment_interval=] and <dfn noexport>SI</dfn> = the value of [=segment_interval=].
 	- When [=CSI=] != 0, [=NS=] x [=CSI=] shall be equal to or greater than [=D=].
 		- If [=NS=] x [=CSI=] > [=D=], the actual interval of the last segment shall be [=D=] - ([=NS=] - 1) x [=CSI=].
@@ -950,7 +950,7 @@ Parameter definition classes shall inherit from the abstract <dfn noexport>Param
 ```
 abstract class ParamDefinition() {
   leb128() parameter_id;
-  leb128() time_base;
+  leb128() parameter_rate;
 }
 ```
 
@@ -958,7 +958,7 @@ abstract class ParamDefinition() {
 
 <dfn value noexport for="ParamDefinition()">parameter_id</dfn> shall indicate the unique ID in an IA sequence for a given parameter.
 
-<dfn value noexport for="ParamDefinition()">time_base</dfn> shall specify the time base used by this parameter, expressed as seconds per tick. Time-related fields associated with this parameter, such as durations and intervals, shall be expressed in the number of ticks.
+<dfn value noexport for="ParamDefinition()">parameter_rate</dfn> shall specify the rate used by this parameter, expressed as ticks per second. Time-related fields associated with this parameter, such as durations and intervals, shall be expressed in the number of ticks.
 
 ### Audio Frame OBU Syntax and Semantics ### {#obu-audioframe}
 
@@ -1060,7 +1060,7 @@ For this version of the specification, the value of reinitialize_decoder shall b
 
 <dfn noexport>relative_offset</dfn> is the offset to position the first audio frame (before trimming) or parameter block with the referenced obu_id that comes after this Sync OBU with respect to the timeline generated before this Sync OBU. If this Sync OBU is the first one, it is the offset from 0. Otherwise, it is the offset from the end of the timeline of Substreams generated from the previous Sync OBU.
 
-The offset shall be indicated in the number of ticks at the time_base specified in the corresponding substream or parameter definition. 
+The offset shall be indicated in the number of ticks at the [=parameter_rate=] specified in the corresponding substream or parameter definition.
 
 IA encoder and decoder operations related to this field are specified in [[#standalone-synchronizing-data-obus]].
 
@@ -2443,36 +2443,52 @@ The rendered and processed audio elements are then summed, and then apply [=outp
 
 ## Animated Parameters ## {#processing-animated-params}
 
-This section describes how a set of parameters is animated over a segment in a parameter block, using the information provided in [=AnimatedParameterData()=].
+This section describes how a set of parameters is animated over a segment in a parameter block and applied to the corresponding audio samples, using the information provided in [=AnimatedParameterData()=].
 
-Let P0, P1 and P2 be 2D coordinates defined as
+If [=animation_type=] is equal to STEP, the parameter value provided by [=start_point_value=] should be applied to all time steps in the segment.
 
-```
-P0 = (t_start, start_point_value),
-P1 = (t_control, control_point_value),
-P2 = (t_end, end_point_value),
-```
-
-where t_start is the segment start time, t_end is the segment end time and t_control is the control point time given by
+If [=animation_type=] is equal to LINEAR or BEZIER, the information provided in [=AnimatedParameterData()=] describes how the parameter is animated as a Bezier curve. Let <code>T</code> be the segment interval defined in the [=parameter_block_obu=] and <code>P0</code>, <code>P1</code> and <code>P2</code> be 2D coordinates defined as
 
 ```
-t_control = t_start + (t_end - t_start) * control_point_relative_time.
+P0 = (t0, start_point_value),
+P1 = (t1, control_point_value),
+P2 = (t2, end_point_value),
 ```
 
-If [=animation_type=] is equal to STEP, the parameter value provided by [=start_point_value=] should be applied immediately to all samples of the segment.
+where <code>t0 = 0</code> is the segment start time, <code>t2 = T - 1</code> and <code>t1</code> is the control point time given by
 
-If [=animation_type=] is equal to LINEAR, the parameter value is linearly interpolated between [=start_point_value=] and [=end_point_value=] as follows:
+```
+t1 = round(T * control_point_relative_time) - 1.
+```
+
+The values of <code>t0</code>, <code>t1</code> and <code>t2</code> are expressed as ticks at the [=parameter_rate=] given in the associated parameter definition. To compute the parameter values for each audio sample, the [=parameter_rate=] must be resampled to the audio sample rate to give:
+
+```
+n0 = t0 * audio_sample_rate / parameter_rate = 0
+n1 = t1 * audio_sample_rate / parameter_rate
+n2 = t2 * audio_sample_rate / parameter_rate
+```
+
+Then, <code>P0</code>, <code>P1</code>, <code>P2</code> can be rewritten as:
+
+```
+P0 = (n0, start_point_value),
+P1 = (n1, control_point_value),
+P2 = (n2, end_point_value),
+```
+
+If [=animation_type=] is equal to LINEAR, the parameter value is linearly interpolated between [=start_point_value=] and [=end_point_value=] at a given audio sample index in the segment as follows:
 
 ```
 B_linear(a) = (1 - a) * P0 + a * P2,
-0 <= a <= 1.
+a = [0, 1, 2, ..., n2] / n2.
 ```
 
-If [=animation_type=] is equal to BEZIER, the parameter value is interpolated following a quadratic Bezier curve between [=start_point_value=] and [=end_point_value=] as follows:
+If [=animation_type=] is equal to BEZIER, the parameter value is interpolated following a quadratic Bezier curve between [=start_point_value=] and [=end_point_value=] at a given audio sample index in the segment as follows:
 
 ```
 B_quad(a) = (1 - a)^2 * P0 + 2 * (1 - a) * a * P1 + a^2 * P2,
-0 <= a <= 1.
+a = [0, 1, 2, ..., n2] / n2.
 ```
 
 ## Post Processing ## {#processing-post}

--- a/index.bs
+++ b/index.bs
@@ -2528,8 +2528,8 @@ a = -beta + sqrt((beta^2) - (4 * alpha * gamma)) ÷ (2 * alpha),
 where
 
 ```
-alpha = (n0 - n) - 2 * (n1 - n) + (n2 - n),
-beta = -2 * (n0 - n) + 2 * (n1 - n),
+alpha = n0 - 2 * n1 + n2,
+beta = 2 * (n1 - n0),
 gamma = n0 - n.
 ```
 

--- a/index.bs
+++ b/index.bs
@@ -251,6 +251,12 @@ All of syntax elements shall conform to [=Syntactic Description Language=] speci
   <td>*</td><td>Multiplication.</td>
 </tr>
 <tr>
+  <td>÷</td><td>Floating point (arithmetic) division.</td>
+</tr>
+<tr>
+  <td>/</td><td>Integer division with truncation of the result toward zero.</td>
+</tr>
+<tr>
   <td>floor(x)</td><td>The largest integer that is smaller than or equal to x.</td>
 </tr>
 <tr>
@@ -279,9 +285,17 @@ class Bar {
 
 ### Mathematical functions ### {#convention-function-mathematical}
  
- <b>Clip3(x, y, z)</b>
+<b>Clip3(x, y, z)</b>
  
- It shall conform to [=Clip3=] specified in [[!AV1-Convention]].
+It shall conform to [=Clip3=] specified in [[!AV1-Convention]].
+
+<b>round(x)</b>
+
+The round() function returns the integer value closest to <code>x</code> and may be implemented as
+
+```
+round(x) = floor(x + 0.5).
+```
  
 ### Function UTF-8 Encoding ### {#convention-function-utf8}
 
@@ -2461,12 +2475,32 @@ where <code>t0 = 0</code> is the segment start time, <code>t2 = T - 1</code> and
 t1 = round(T * control_point_relative_time) - 1.
 ```
 
-The values of <code>t0</code>, <code>t1</code> and <code>t2</code> are expressed as ticks at the [=parameter_rate=] given in the associated parameter definition. To compute the parameter values for each audio sample, the [=parameter_rate=] must be resampled to the audio sample rate to give:
+The values of <code>t0</code>, <code>t1</code> and <code>t2</code> are expressed as ticks at the [=parameter_rate=] given in the associated parameter definition.
+
+If [=animation_type=] is equal to LINEAR, the parameter value is linearly interpolated between [=start_point_value=] and [=end_point_value=] at a given point in time as:
 
 ```
-n0 = t0 * audio_sample_rate / parameter_rate = 0
-n1 = t1 * audio_sample_rate / parameter_rate
-n2 = t2 * audio_sample_rate / parameter_rate
+B_linear(a) = (1 - a) * P0 + a * P2,
+0 <= a <= 1,
+```
+
+where <code>B_linear(a) = (t, y)</code> is a 2D coordinate with the parameter value <code>y</code> at time <code>t</code>.
+
+If [=animation_type=] is equal to BEZIER, the parameter value is interpolated following a quadratic Bezier curve between [=start_point_value=] and [=end_point_value=] at a given point in time as:
+
+```
+B_quad(a) = (1 - a)^2 * P0 + 2 * (1 - a) * a * P1 + a^2 * P2,
+0 <= a <= 1.
+```
+
+where <code>B_quad(a) = (t, y)</code> is a 2D coordinate with parameter value <code>y</code> at time <code>t</code>.
+
+To apply the parameter values to the audio samples in the segment without interpolation, the [=parameter_rate=] is first resampled to the audio sample rate to give:
+
+```
+n0 = t0 * audio_sample_rate / parameter_rate,
+n1 = t1 * audio_sample_rate / parameter_rate,
+n2 = t2 * audio_sample_rate / parameter_rate.
 ```
 
 Then, <code>P0</code>, <code>P1</code>, <code>P2</code> can be rewritten as:
@@ -2474,22 +2508,31 @@ Then, <code>P0</code>, <code>P1</code>, <code>P2</code> can be rewritten as:
 ```
 P0 = (n0, start_point_value),
 P1 = (n1, control_point_value),
-P2 = (n2, end_point_value),
+P2 = (n2, end_point_value).
 ```
 
-If [=animation_type=] is equal to LINEAR, the parameter value is linearly interpolated between [=start_point_value=] and [=end_point_value=] at a given audio sample index in the segment as follows:
+Next, the parameter value <code>y</code> is computed for each time <code>t</code> that corresponds to an integer audio sample index, <code>t = n = [0, 1, 2, ..., n2]</code>. This is done by computing the equivalent value of <code>a</code> for every <code>n</code>, and then applying the Bezier equations <code>B_linear(a)</code> and <code>B_quad(a)</code> to find the parameter value <code>y</code>.
+
+In the case of <code>B_linear(a)</code>, the mapping between <code>n</code> and <code>a</code> is given by:
 
 ```
-B_linear(a) = (1 - a) * P0 + a * P2,
-a = [0, 1, 2, ..., n2] / n2.
+a = n ÷ n2.
 ```
 
-If [=animation_type=] is equal to BEZIER, the parameter value is interpolated following a quadratic Bezier curve between [=start_point_value=] and [=end_point_value=] at a given audio sample index in the segment as follows:
+In the case of <code>B_quad(a)</code>, the mapping between <code>n</code> and <code>a</code> is given by:
 
 ```
-B_quad(a) = (1 - a)^2 * P0 + 2 * (1 - a) * a * P1 + a^2 * P2,
-a = [0, 1, 2, ..., n2] / n2.
+a = -beta + sqrt((beta^2) - (4 * alpha * gamma)) ÷ (2 * alpha),
 ```
+
+where
+
+```
+alpha = (n0 - n) - 2 * (n1 - n) + (n2 - n),
+beta = -2 * (n0 - n) + 2 * (n1 - n),
+gamma = n0 - n.
+```
+
 
 ## Post Processing ## {#processing-post}
 


### PR DESCRIPTION
Fixes #223


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/pull/244.html" title="Last updated on Jan 30, 2023, 10:44 PM UTC (d84f825)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/244/13ec14c...d84f825.html" title="Last updated on Jan 30, 2023, 10:44 PM UTC (d84f825)">Diff</a>