### PR TITLE
Fix #261 (update OPUS codec_id from 'opus' to 'Opus')

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -49,7 +49,7 @@ url: https://opus-codec.org/docs/opus_in_isobmff.html#; spec: OPUS-IN-ISOBMFF; t
 
 
 url: https://opus-codec.org/docs/opus_in_isobmff.html#; spec: OPUS-IN-ISOBMFF; type: property;
-	text: opus
+	text: Opus
 	text: dOps
 
 url: https://www.iso.org/standard/55688.html#; spec: MP4-Systems; type: dfn;
@@ -587,7 +587,7 @@ class codec_config() {
 
 <dfn noexport>codec_config_id</dfn> shall indicate a unique ID in an IA sequence for a given codec config.
 
-<dfn noexport>codec_id</dfn> shall be a ‘four-character code’ (4CC) to identify the codec used to generate the audio substreams. It shall be 'opus' for IAMF-OPUS, 'mp4a' for IAMF-AAC-LC, 'fLaC' for IAMF-FLAC and 'lpcm' for IAMF-LPCM.
+<dfn noexport>codec_id</dfn> shall be a ‘four-character code’ (4CC) to identify the codec used to generate the audio substreams. It shall be 'Opus' for IAMF-OPUS, 'mp4a' for IAMF-AAC-LC, 'fLaC' for IAMF-FLAC and 'lpcm' for IAMF-LPCM.
 
 For ISOBMFF encapsulation, it shall be the same as the [=boxtype=] of its AudioSampleEntry if exist. 
 
@@ -1666,7 +1666,7 @@ For legacy codecs, Decoder_Config() shall be exactly the same information as the
 
 ### IAMF-OPUS Specific ### {#iamf-opus-specific}
 
-[=Codec_ID=] shall be 'opus'.
+[=Codec_ID=] shall be 'Opus'.
 
 Codec_Specific_Info for IAMF-OPUS shall conform to [=ID Header=] with [=ChannelMappingFamily=] = 0 of [[!RFC7845]] with following constraints:
 - [=Channel Count=] must be set to 2. [=Channel Count=] can be ignored because the real value can be determined from the Audio Element OBU and from the opus packet header.
@@ -1795,7 +1795,7 @@ Restrictions on IA sequence:
 - [=version=] shall be set to 0 for this version of specification.
 - [=profile_version=] shall be set to 32 for this version of specification.
 - The different Codec Config OBUs may have different [=codec_id=]s specified with the following constraints:
-    - The combination of [=codec_id=] = 'fLaC' for one substream and [=codec_id=] = 'opus' for another substream shall not be allowed.
+    - The combination of [=codec_id=] = 'fLaC' for one substream and [=codec_id=] = 'Opus' for another substream shall not be allowed.
     - The combination of [=codec_id=] = 'fLaC' for one substream and [=codec_id=] = 'mp4a' for another substream shall not be allowed.
 - [=num_layers=] shall be set to 1 or up to 6 for Channel-based audio element (i.e. scalable channel audio)
     - In this case, [=demixing_info_parameter_data()=] and [=recon_gain_info_parameter_data()=] may be present.
@@ -2028,7 +2028,7 @@ This section describes a <dfn noexport>codec specific box</dfn> for the decoding
 
 #### OPUS Specific Box #### {#codecspecificbox-opus}
 
-This shall be [=OpusSpecificBox=] ('dOps') for 'opus' AudioSampleEntry which is specified in [[!OPUS-IN-ISOBMFF]].
+This shall be [=OpusSpecificBox=] ('dOps') for 'Opus' AudioSampleEntry which is specified in [[!OPUS-IN-ISOBMFF]].
 
 <pre class="def">
 	Box Type:  <dfn export>dOps</dfn>
@@ -2042,7 +2042,7 @@ This box shall be for one single substream.
 
 <b>Syntax</b>
 
-It shall be the same as 'dOps' box for 'opus' with that [=ChannelMappingFamily=] shall be set to 0.
+It shall be the same as 'dOps' box for 'Opus' with that [=ChannelMappingFamily=] shall be set to 0.
 
 <b>Semantics</b>
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/pull/262.html" title="Last updated on Feb 1, 2023, 7:16 AM UTC (14623c9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/262/0483198...14623c9.html" title="Last updated on Feb 1, 2023, 7:16 AM UTC (14623c9)">Diff</a>