### PR TITLE
Fix #258 (change 'lpcm' into 'ipcm')

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -587,7 +587,7 @@ class codec_config() {
 
 <dfn noexport>codec_config_id</dfn> shall indicate a unique ID in an IA sequence for a given codec config.
 
-<dfn noexport>codec_id</dfn> shall be a ‘four-character code’ (4CC) to identify the codec used to generate the audio substreams. It shall be 'opus' for IAMF-OPUS, 'mp4a' for IAMF-AAC-LC, 'fLaC' for IAMF-FLAC and 'lpcm' for IAMF-LPCM.
+<dfn noexport>codec_id</dfn> shall be a ‘four-character code’ (4CC) to identify the codec used to generate the audio substreams. It shall be 'opus' for IAMF-OPUS, 'mp4a' for IAMF-AAC-LC, 'fLaC' for IAMF-FLAC and 'ipcm' for IAMF-LPCM.
 
 For ISOBMFF encapsulation, it shall be the same as the [=boxtype=] of its AudioSampleEntry if exist. 
 
@@ -1704,12 +1704,12 @@ Substream format shall be [=FRAME=] of [[!FLAC]], which is composed of [=FRAME_H
 
 ### IAMF-LPCM Specific ### {#iamf-lpcm-specific}
 
-[=Codec_ID=] shall be 'lpcm'.
+[=Codec_ID=] shall be 'ipcm'.
 
 [=Decoder_Config()=] for IAMF-LPCM shall be as follows:
 
 ```
-class decoder_config(lpcm) {
+class decoder_config(ipcm) {
   unsigned int (32) sample_rate;
   unsigned int (8) sample_size;
 }
@@ -2123,7 +2123,7 @@ DASH and other applications require defined values for the 'Codecs' parameter sp
 - For IAMF-LPCM
 
 ```
-	iamf.IAMF-specific-needs.lpcm
+	iamf.IAMF-specific-needs.ipcm
 ```
 
 <b>IAMF-specific-needs</b> shall be <b>V.PV</b> as follows:


### PR DESCRIPTION
Fix #258


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/pull/263.html" title="Last updated on Feb 7, 2023, 2:36 AM UTC (965add1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/263/88014a4...965add1.html" title="Last updated on Feb 7, 2023, 2:36 AM UTC (965add1)">Diff</a>