### PR TITLE
Encapsulate descriptor OBUs in ISOBMFF's audio sample entries.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1971,8 +1971,7 @@ During encapsulation process, OBUs of IA sequence are encapsulated into [[!ISOBM
     - The [=num_samples_per_frame=] field in the Codec Config OBU is copied to 'stts'.
     - The [=roll_distance=] field in the Codec Config OBU is copied to [=AudioPreRollEntry()=] with the [=grouping_type=] 'prol'.
 - Each temporal unit:
-	- Temporal Delimiter OBU: shall be discarded if present.
-	- Parameter Block OBU for demixing_info_parameter_data() (with OBU syntax) shall be stored as a new sample group having [=grouping_type=], [=demi=].
+	- Temporal Delimiter OBU: shall be discarded if present.	
 	- Remained OBUs of each temporal unit shall be stored as one sample data without gap among OBUs.
 - Audio Frame OBUs:
 	- Select one substream. 

--- a/index.bs
+++ b/index.bs
@@ -2017,7 +2017,7 @@ None of AudioSampleEntry's optional boxes shall be present.
 	Box Type:  <dfn export>iamd</dfn>
 	Container: IA Sample Entry ('iamf')
 	Mandatory: Yes
-	Quantity:  One or more.
+	Quantity:  One.
 </pre>
 
 <dfn noexport>IA_Descriptor</dfn> contains one set of IAMF Descriptor OBUs, specified using the OBU syntax.
@@ -2038,6 +2038,7 @@ class IA_Descriptor extends Box('iamd') {
   for (j = 0; j < num_mix_presentations; j++) {
     mix_presentation_obu();
   }
+  sync_obu();
 }
 ```
 
@@ -2055,19 +2056,12 @@ class IA_Descriptor extends Box('iamd') {
 
 <dfn value noexport for="IA_Descriptor">mix_presentation_obu()</dfn> is the <code>j</code>-th [=mix_presentation_obu()=] in this set of descriptor OBUs.
 
+<dfn value noexport for="IA_Descriptor">sync_obu()</dfn> is the [=sync_obu()=] that immediately follows this set of descriptor OBUs.
+
 ### IA Sample Format ### {#iasampleformat}
 
 For tracks using the [=IASampleEntry=], an <dfn noexport>IA Sample</dfn> has the following constraints:
 - The one sample data shall be the remained OBUs of each temporal unit after processing of [[#isobmff-singletrack-basicencapsulationscheme]].
-
-### IA Sample Group ### {#iasamplegroup}
-
-#### Demixing Info Sample Group #### {#iasamplegroup-demixing}
-
-During encapsulation process, Parameter Block OBU for demixing_info_parameter_data shall be discarded from IA sequence. A new sample group for demixing_info_parameter_data() shall be defined by using 'sgpd' and 'sbgp' boxes with following requirements:
-- [=grouping_type=] shall be set to <dfn noexport>demi</dfn>.
-- Each [=SampleGroupDescriptionEntry=] shall be Parameter Block OBU for demixing_info_parameter_data with OBU syntax.
-
 
 ## Common Encryption ## {#CommonEncryption}
 TBA
@@ -2134,27 +2128,16 @@ Below figure shows the mirroring process of the encapsulation scheme of IA seque
 
 
 During decapsulation process, IAMF file is decapsulated into IA sequences which conform to [[#obu-syntax]] as follows:
-- Step1: Reconstruction of descriptor OBUs (one Magic Code OBU, one Codec Config OBU, one or more Mix Presentation OBUs and one or more Audio Element OBUs) for the ith IA sequence.
-	- [Step1-1] Magic Code OBU: take version and profile_version fields from <code>iamf</code> sample entry and packetize it with [=ia_code=] and the pre-fixed header value (i.e. 0xF006) by OBU.
-	- [Step1-2] Codec Config OBU: generate [=codec_id=] and [=decoder_config()=] from CodecSpecificBox of <code>iamf</code> sample entry, num_samples_per_frame from 'stts' box and take roll_distance from [=AudioPreRollEntry=], and packetize it by OBU with obu_type = OBU_IA_Codec_Config.
-	- [Step1-3] Mix Presentation OBUs and Audio Element OBUs: take the ith SampleGroupDescriptionEntry as it is in SampleGroup with grouping_type, [=iagd=].
-	- [Step1-4] Figure out the offset (i1) and number (im) of Samples, which the ith SampleGroupDescriptionEntry is applied to, from the SampleGroup.
-- Step2: Prepare Sync_OBU with obu_type = OBU_IA_Sync.
+- Step1: Reconstruction of descriptor OBUs (one Magic Code OBU, one Codec Config OBU, one or more Audio Element OBUs and one or more Mix Presentation OBUs) for the ith IA sequence.
+	- Magic Code OBU: take the magic_code_obu in the ith AudioSampleEntry('iamf').
+	- Codec Config OBU: take the codec_config_obu in the ith AudioSampleEntry('iamf').
+	- Audio Element OBU(s): take the audio_element_obus in the ith AudioSampleEntry('iamf').
+	- Mix Presentation OBU(s): take the mix_presentation_obus in the ith AudioSampleEntry('iamf').
+- Step2: Reconstruction of Sync_OBU for the ith IA sequence.
+	- Take the sync_obu in the ith AudioSampleEntry('iamf').
 - Step3: Reconstructing of the jth Temporal Unit of the ith IA sequence (j = i1, i2, …, im)
-	- [Step3-1] If there is the SampleGroup with grouping_type = [=demi=], then take the parameter block OBU for the demixing_info and jth sample. Otherwise, take jth sample as it is.
-		- Parameter block OBU for demixing_info: take the SampleGroupDescriptionEntry as it is, from SampleGrouop with grouping_type = [=demi=], mapped to jth Sample.
-	- [Step3-2] Place Sync_OBU at the front of the result of Step2-2 without gap to reconstruct the jth Temporal Unit.
+	- Take jth sample as it is.
 - Step4: Place descriptor OBUs, followed by Sync OBU, and followed by Temporal Units in order (j = i1, i2, …, im) without gap, to reconstruct the ith IA sequence.
-
-[=codec_id=] and [=decoder_config()=] for IAMF-OPUS is generated as follows:
-- The syntax and values shall conform to [=ID Header=] of [[!RFC7845]] with following constraints.
-	- [=OutputChannelCount=], [=PreSkip=], [=InputSampleRate=], [=OutputGain=] and [=ChannelMappingFamily=] are copied from [=dOps=] box.
-	
-
-[=codec_id=] and [=decoder_config()=] for IAMF-AAC-LC is generated as follows:
-- [=codec_id=]: 'mp4a'
-- [=decoder_config()=] is generated from [=DecoderConfigDescriptor()=] of [=esds=] box.
-
 
 # IAMF processing # {#processing}
 

--- a/index.bs
+++ b/index.bs
@@ -1732,6 +1732,7 @@ Restrictions on the IA sequence:
 - There shall be only one unique Codec Config OBU.
 - There shall be only one unique Audio Element OBU.
 - There shall be only one unique set of Descriptor OBUs.
+- There shall be only one Sync OBU placed immediately after each set of Descriptor OBUs, and no additional new Sync OBUs inserted anywhere in the sequence of data OBUs that follow.
 - There shall not be any Temporal Delimiter OBUs present.
 - [=version=] shall be set to 0 for this version of specification.
 - [=profile_version=] shall be set to 0 for this version of specification.
@@ -1757,6 +1758,7 @@ Restrictions on IA sequence:
 - There shall be only one unique Codec Config OBU.
 - There shall be at most two unique Audio Element OBUs at any one time.
 - There may be more than one unique set of Descriptor OBUs.
+- There shall be only one Sync OBU placed immediately after each set of Descriptor OBUs, and no additional new Sync OBUs inserted anywhere in the sequence of data OBUs that follow.
 - There may be Temporal Delimiter OBUs present.
 - [=version=] shall be set to 0 for this version of specification.
 - [=profile_version=] shall be set to 16 for this version of specification.

--- a/index.bs
+++ b/index.bs
@@ -569,7 +569,6 @@ This section specifies the OBU payload of OBU_IA_Codec_Config.
 class codec_config_obu() {
   leb128() codec_config_id;  
   codec_config();
-
 }
 
 class codec_config() {
@@ -577,7 +576,6 @@ class codec_config() {
   leb128() num_samples_per_frame;
   signed int (16) roll_distance;
   decoder_config(codec_id);
-
 }
 ```
 
@@ -586,8 +584,6 @@ class codec_config() {
 <dfn noexport>codec_config_id</dfn> indicates a unique ID in an IA sequence for a given codec config.
 
 <dfn noexport>codec_id</dfn> indicates a ‘four-character code’ (4CC) to identify the codec used to generate the audio substreams. It shall be 'Opus' for IAMF-OPUS, 'mp4a' for IAMF-AAC-LC, 'fLaC' for IAMF-FLAC and 'ipcm' for IAMF-LPCM.
-
-For ISOBMFF encapsulation, it shall be the same as the [=boxtype=] of its AudioSampleEntry if exist. 
 
 <dfn noexport>num_samples_per_frame</dfn> indicates the frame length, in samples, of the raw coded audio provided in by audio_frame_obu(). It shall not be set to zero.
 
@@ -1968,13 +1964,10 @@ IA sequence shall comply with the bitstream which is specified in [[#profiles-si
 ### Encapsulation Scheme ### {#isobmff-singletrack-basicencapsulationscheme}
 
 During encapsulation process, OBUs of IA sequence are encapsulated into [[!ISOBMFF]] as follows:
-- Magic Code OBU: version and profile version fields shall be moved to IASampleEntry.
-- Codec Config OBU: 
-	- codec_id and decoder_config() shall move to IASampleEntry.
-	- num_samples_per_frame shall move to 'stts'.
-	- roll_distance shall be stored as [=AudioPreRollEntry=] having [=grouping_type=], 'prol'.
-- Mix Presentation OBUs and Audio Element OBUs (with OBU syntax) shall be stored as a new sample group having [=grouping_type=], [=iagd=].
-- Sync OBU: parse the input timeline using the Sync OBU information and construct a PTRO box that describes the relative offsets for each parameter block.
+
+- Each set of descriptor OBUs, specified in [[#standalone-descriptor-obus]], and the Sync OBU that immediately follows them are moved to one [=IASampleEntry=]. The descriptor OBUs are then discarded from the IA sequence. In addition,
+    - The [=num_samples_per_frame=] field in the Codec Config OBU is copied to 'stts'.
+    - The [=roll_distance=] field in the Codec Config OBU is copied to [=AudioPreRollEntry()=] with the [=grouping_type=] 'prol'.
 - Each temporal unit:
 	- Temporal Delimiter OBU: shall be discarded if present.
 	- Parameter Block OBU for demixing_info_parameter_data() (with OBU syntax) shall be stored as a new sample group having [=grouping_type=], [=demi=].
@@ -1984,10 +1977,10 @@ During encapsulation process, OBUs of IA sequence are encapsulated into [[!ISOBM
 	- If [=obu_trimming_status_flag=] of the first Audio Frame OBU of the substream is set to 1, keep parsing following Audio Frame OBUs of the substream until meets the Audio Frame OBU having [=obu_trimming_status_flag=] =  0 and sum [=num_samples_to_trim_at_start=]. Then reflect the result of the summation to 'edts'.
 	- If [=obu_trimming_status_flag=] of the last Audio Frame OBU of the substream is set to 1, then reflect num_samples_to_trim_at_end to 'stts.
 	
-
 <center><img src="images/IAC Encapsulation Guideline.png" style="width:100%; height:auto;"></center>
 <center><figcaption>IAMF Encapsulation Scheme</figcaption></center>
 
+ISSUE: TODO: update the IAMF Encapsulation Scheme figure.
 
 ### IA Sample Entry ### {#iasampleentry-section}
 
@@ -1998,82 +1991,67 @@ During encapsulation process, OBUs of IA sequence are encapsulated into [[!ISOBM
 	Quantity:          One or more.
 </pre>
 
-
-The <dfn noexport>IASampleEntry</dfn> identifies that the track contains [=IA Samples=], and uses one single [=codec specific box=].
+<dfn noexport>IASampleEntry</dfn> identifies that the track contains [=IA Samples=], and contains one IA_Descriptor.
 
 <b>Syntax</b>
 
 ```
 class IASampleEntry extends AudioSampleEntry('iamf') {
-  unsigned int (8) version;
-  unsigned int (8) profile_version;
-  CodecSpecificBox config;
+  IA_Descriptor ia_descriptor;
 }
 ```
 
-No optional boxes of AudioSampleEntry shall present.
+The [=channelcount=] and [=samplerate=] fields of AudioSampleEntry are unused.
+
+None of AudioSampleEntry's optional boxes shall be present.
 
 <b>Semantics</b>
 
-Both [=channelcount=] and [=samplerate=] fields of AudioSampleEntry shall be ignored.
+<dfn noexport>ia_descriptor</dfn> is the IA_Descriptor box in this stream.
 
-version and profile_version shall be the same as [=version=] and [=profile_version=] in magic_code_obu, respectively.
-
-
-### Codec Specific Box ### {#codecspecificbox-section}
-
-This section describes a <dfn noexport>codec specific box</dfn> for the decoding parameters, which is defined by codec_id of audio_substream_config(), to decode one single substream of IA sequence. <code>iamf</code> shall contain only one single codec specific box regardless of the number of substreams in IA sequence. So, the codec specific box is applied to all of substreams in sample data.
-
-#### OPUS Specific Box #### {#codecspecificbox-opus}
-
-This shall be [=OpusSpecificBox=] ('dOps') for 'Opus' AudioSampleEntry which is specified in [[!OPUS-IN-ISOBMFF]].
+### IA Descriptors ### {#iadescriptors-section}
 
 <pre class="def">
-	Box Type:  <dfn export>dOps</dfn>
+	Box Type:  <dfn export>iamd</dfn>
 	Container: IA Sample Entry ('iamf')
 	Mandatory: Yes
-	Quantity:  One
+	Quantity:  One or more.
 </pre>
 
-
-This box is for one single substream.
+<dfn noexport>IA_Descriptor</dfn> contains one set of IAMF Descriptor OBUs, specified using the OBU syntax.
 
 <b>Syntax</b>
 
-It shall be the same as 'dOps' box for 'Opus' with that [=ChannelMappingFamily=] shall be set to 0.
+```
+class IA_Descriptor extends Box('iamd') {
+  magic_code_obu();
+  codec_config_obu();
+
+  leb128() num_audio_elements;
+  for (i = 0; i < num_audio_elements; i++) {
+    audio_element_obu();
+  }
+
+  leb128() num_mix_presentations;
+  for (j = 0; j < num_mix_presentations; j++) {
+    mix_presentation_obu();
+  }
+}
+```
 
 <b>Semantics</b>
 
-It shall be the same as the semantics in [[!OPUS-IN-ISOBMFF]] except followings:
-- [=OutputChannelCount=] must be set to 2. [=OutputChannelCount=] can be ignored because the real value can be determined from the Audio Element OBU and from the [=opus packet=] header.
-- In case of [=num_layers=] > 1, [=OutputGain=] shall be set to 0.
-- [=ChannelMappingFamily=] shall be set to 0.
+<dfn value noexport for="IA_Descriptor">magic_code_obu()</dfn> is the [=magic_code_obu()=] in this set of descriptor OBUs.
 
-#### MP4A Specific Box #### {#codecspecificbox-mp4a}
+<dfn value noexport for="IA_Descriptor">codec_config_obu()</dfn> is the [=codec_config_obu()=] in this set of descriptor OBUs.
 
-This shall be [=ESDBox=] ('esds') for 'mp4a' which is specified in [[!MP4]].
+<dfn value noexport for="IA_Descriptor">num_audio_elements()</dfn> is the number of audio element OBUs in this set of descriptor OBUs.
 
+<dfn value noexport for="IA_Descriptor">audio_element_obu()</dfn> is the <code>i</code>-th [=audio_element_obu()=] in this set of descriptor OBUs.
 
-<pre class="def">
-	Box Type:  <dfn export>esds</dfn>
-	Container: IA Sample Entry ('iamf')
-	Mandatory: Yes
-	Quantity:  One of more
-</pre>
+<dfn value noexport for="IA_Descriptor">num_mix_presentations</dfn> is the number of mix presentation OBUs in this set of descriptor OBUs.
 
-
-This box is for one single Substream.
-
-<b>Syntax</b>
-
-It shall be the same as 'esds' box for [=Low Complexity Profile=] of [[!AAC]] (AAC-LC).
-
-<b>Semantics</b>
-
-It shall be the same as the semantics in 'esds' except followings:
-- [=channelConfiguration=] field must be set to 2. The real value can be implied from the Audio Element OBU.
-
-ISSUE: We need to add specific boxes for FLAC and LPCM.
+<dfn value noexport for="IA_Descriptor">mix_presentation_obu()</dfn> is the <code>j</code>-th [=mix_presentation_obu()=] in this set of descriptor OBUs.
 
 ### IA Sample Format ### {#iasampleformat}
 
@@ -2081,12 +2059,6 @@ For tracks using the [=IASampleEntry=], an <dfn noexport>IA Sample</dfn> has the
 - The one sample data shall be the remained OBUs of each temporal unit after processing of [[#isobmff-singletrack-basicencapsulationscheme]].
 
 ### IA Sample Group ### {#iasamplegroup}
-
-#### Global Descriptor Sample Group #### {#iasamplegroup-globaldescriptor}
-
-During encapsulation process, global descriptors shall be discarded from IA sequence. A new sample group for global descriptors shall be defined by using 'sgpd' and 'sbgp' boxes with following requirements:
-- [=grouping_type=] shall be set to <dfn noexport>iagd</dfn>.
-- [=SampleGroupDescriptionEntry=] shall be Mix Presentation OBUs and followed by Audio Element OBUs with OBU syntax.
 
 #### Demixing Info Sample Group #### {#iasamplegroup-demixing}
 

--- a/index.bs
+++ b/index.bs
@@ -2027,13 +2027,11 @@ None of AudioSampleEntry's optional boxes shall be present.
 class IA_Descriptor extends Box('iamd') {
   magic_code_obu();
   codec_config_obu();
-
-  leb128() num_audio_elements;
+  
   for (i = 0; i < num_audio_elements; i++) {
     audio_element_obu();
   }
 
-  leb128() num_mix_presentations;
   for (j = 0; j < num_mix_presentations; j++) {
     mix_presentation_obu();
   }
@@ -2047,11 +2045,7 @@ class IA_Descriptor extends Box('iamd') {
 
 <dfn value noexport for="IA_Descriptor">codec_config_obu()</dfn> is the [=codec_config_obu()=] in this set of descriptor OBUs.
 
-<dfn value noexport for="IA_Descriptor">num_audio_elements()</dfn> is the number of audio element OBUs in this set of descriptor OBUs.
-
 <dfn value noexport for="IA_Descriptor">audio_element_obu()</dfn> is the <code>i</code>-th [=audio_element_obu()=] in this set of descriptor OBUs.
-
-<dfn value noexport for="IA_Descriptor">num_mix_presentations</dfn> is the number of mix presentation OBUs in this set of descriptor OBUs.
 
 <dfn value noexport for="IA_Descriptor">mix_presentation_obu()</dfn> is the <code>j</code>-th [=mix_presentation_obu()=] in this set of descriptor OBUs.
 

--- a/index.bs
+++ b/index.bs
@@ -1997,7 +1997,7 @@ ISSUE: TODO: update the IAMF Encapsulation Scheme figure.
 
 ```
 class IASampleEntry extends AudioSampleEntry('iamf') {
-  IA_Descriptor ia_descriptor;
+  IA_Descriptor descriptor;
 }
 ```
 
@@ -2007,7 +2007,7 @@ None of AudioSampleEntry's optional boxes shall be present.
 
 <b>Semantics</b>
 
-<dfn noexport>ia_descriptor</dfn> is the IA_Descriptor box in this stream.
+<dfn noexport>descriptor</dfn> is the IA_Descriptor box in this stream.
 
 ### IA Descriptors ### {#iadescriptors-section}
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/pull/279.html" title="Last updated on Feb 21, 2023, 2:56 AM UTC (9b5069a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/279/22780a1...9b5069a.html" title="Last updated on Feb 21, 2023, 2:56 AM UTC (9b5069a)">Diff</a>