### PR TITLE
Fix #268, trimming flag only at the beginning and end of substreams

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -517,6 +517,11 @@ It shall always be set to 0 for the following obu_type values:
 
 <dfn noexport>obu_trimming_status_flag</dfn> indicates whether this OBU has audio samples to be trimmed or not. If it is set to 0, the [=num_samples_to_trim_at_start=] and [=num_samples_to_trim_at_end=] fields shall not be present. Otherwise, the [=num_samples_to_trim_at_start=] and [=num_samples_to_trim_at_end=] fields shall be present.
 
+For a given substream, 
+- The substream may have audio samples to be trimmed only at the beginning and/or end of the substream.
+- Thus, this flag may be set to 1 only for one or more consecutive Audio Frame OBUs at the beginning of the substream and/or only for one or more consecutive Audio Frame OBUs at the end of the substream.
+- If the substream has no audio samples to be trimmed, then [=obu_trimming_status_flag=] shall be set to 0 for every Audio Frame OBU of the substream. 
+
 <dfn noexport>obu_extension_flag</dfn> indicates whether the [=extension_header_size=] field presents or not. If it set to 0, the [=extension_header_size=] field shall not be present. Otherwise, the [=extension_header_size=] field shall be present.
 
 This flag shall be set to 0 for the current version of the specification (i.e. [=version=] = 0). An IAMF-OBU parser which is conformant with the current version of the specification shall be able to parse this flag and [=extension_header_size=].

--- a/index.bs
+++ b/index.bs
@@ -518,9 +518,8 @@ It shall always be set to 0 for the following obu_type values:
 <dfn noexport>obu_trimming_status_flag</dfn> indicates whether this OBU has audio samples to be trimmed or not. If it is set to 0, the [=num_samples_to_trim_at_start=] and [=num_samples_to_trim_at_end=] fields shall not be present. Otherwise, the [=num_samples_to_trim_at_start=] and [=num_samples_to_trim_at_end=] fields shall be present.
 
 For a given substream, 
-- The substream may have audio samples to be trimmed only at the beginning and/or end of the substream.
-- Thus, this flag may be set to 1 only for one or more consecutive Audio Frame OBUs at the beginning of the substream and/or only for one or more consecutive Audio Frame OBUs at the end of the substream.
-- If the substream has no audio samples to be trimmed, then [=obu_trimming_status_flag=] shall be set to 0 for every Audio Frame OBU of the substream. 
+- If the substream contains audio samples to be trimmed, then they shall only be at the start and/or end of the substream. Thus, [=obu_trimming_status_flag=] shall be set to 1 only for one or more consecutive Audio Frame OBUs at the start of the substream and/or only for one or more consecutive Audio Frame OBUs at the end of the substream.
+- Otherwise, then [=obu_trimming_status_flag=] shall be set to 0 for every Audio Frame OBU of the substream. 
 
 <dfn noexport>obu_extension_flag</dfn> indicates whether the [=extension_header_size=] field presents or not. If it set to 0, the [=extension_header_size=] field shall not be present. Otherwise, the [=extension_header_size=] field shall be present.
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/pull/292.html" title="Last updated on Feb 27, 2023, 6:08 AM UTC (da33932)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/292/b4e2394...da33932.html" title="Last updated on Feb 27, 2023, 6:08 AM UTC (da33932)">Diff</a>