### PR TITLE
Fix #272, 'roll' replaces 'prol'

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -19,7 +19,7 @@ url: https://www.iso.org/standard/68960.html#; spec: ISOBMFF; type: dfn;
 	text: SampleGroupDescriptionEntry
 	text: channelcount
 	text: samplerate
-	text: AudioPreRollEntry
+	text: AudioRollRecoveryEntry
 
 url: https://www.iso.org/standard/68960.html#; spec: ISOBMFF; type: property;
 	text: iso6
@@ -1857,7 +1857,7 @@ During encapsulation process, OBUs of IA sequence are encapsulated into [[!ISOBM
 
 - Each set of descriptor OBUs, specified in [[#standalone-descriptor-obus]], and the Sync OBU that immediately follows them are moved to one [=IASampleEntry=]. The descriptor OBUs are then discarded from the IA sequence. In addition,
     - The [=num_samples_per_frame=] field in the Codec Config OBU is copied to 'stts'.
-    - The [=roll_distance=] field in the Codec Config OBU is copied to [=AudioPreRollEntry=] with the [=grouping_type=] 'prol'.
+    - The [=roll_distance=] field in the Codec Config OBU is copied to [=AudioRollRecoveryEntry()=] with the [=grouping_type=] 'rol1'.
 - Each temporal unit:
 	- Temporal Delimiter OBU: shall be discarded if present.	
 	- Remained OBUs of each temporal unit shall be stored as one sample data without gap among OBUs.


### PR DESCRIPTION
AudioRollRecoveryEntry ('roll') replaces AudioPreRollEntry ('prol')


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/pull/293.html" title="Last updated on Feb 27, 2023, 6:15 AM UTC (6298ec0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/293/b4e2394...6298ec0.html" title="Last updated on Feb 27, 2023, 6:15 AM UTC (6298ec0)">Diff</a>