### PR TITLE
Fix #287, 16 to 18 channels for base profiles

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1628,7 +1628,7 @@ Restrictions on the IA sequence:
 
 Capabilities of the IA parser, decoder and processor:
 - They shall be able to parse an IA sequence with the MSB four bits of [=profile_version=] = 0 and the MSB four bits of [=version=] = 0 (i.e., profile_version = 0 to 15 and version = 0 to 15).
-- They shall be able to decode and process up to 16 channels.
+- They shall be able to decode and process up to 16 channels.	
 - They shall be able to reconstruct one audio element.
 - They may use demixing_info_parameter_data() to do down-mixing.
 
@@ -1662,7 +1662,9 @@ Restrictions on IA sequence:
 Capabilities of the IA parser, decoder and processor:
 - They shall be able to parse an IA sequence with the MSB four bits of [=profile_version=] = 0 or 1 and the MSB four bits of [=version=] = 0 (i.e., profile_version = 0 to 31 and version = 0 to 15).
 - They shall be able to support the capabilities of the Simple Profile.
-- They shall be able to decode and process up to 16 channels.
+- They shall be able to decode and process up to 18 channels.
+	- Where, 18 channels means not the number of channels after mixing of two Audio Elements but the total sum of channels before mixing of two Audio Elements .
+	- One specific example of 18 channels is 3rd-order Ambisonics (16 channels) + non-diegetic stereo (2 channels).
 - They shall be able to reconstruct two audio elements.
 - They shall be able to mix two audio elements.
 - They shall be able to process short-lived audio elements.


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/pull/303.html" title="Last updated on Mar 3, 2023, 1:32 AM UTC (3203294)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/303/908a94f...3203294.html" title="Last updated on Mar 3, 2023, 1:32 AM UTC (3203294)">Diff</a>