### PR TITLE
Fix #297, Rigidly specified order for Descriptors

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1705,7 +1705,7 @@ This section details the order in which the OBUs are sequenced in a standalone I
 An IA sequence is composed of a series of OBUs in the sequence of a set of descriptor OBUs followed by their associated data OBUs, and where this pattern is repeated as many times as needed.
 
 ### Descriptor OBUs ### {#standalone-descriptor-obus}
-A set of Descriptor OBUs shall be placed at the beginning of the bitstream in the following order:
+A set of Descriptor OBUs shall be placed in the following order regardless of where they appear in the bitstream:
 
 1. One Magic Code OBU
 2. All Codec Config OBUs


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/pull/316.html" title="Last updated on Mar 9, 2023, 7:15 AM UTC (c5760d0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/316/4621c48...c5760d0.html" title="Last updated on Mar 9, 2023, 7:15 AM UTC (c5760d0)">Diff</a>