### PR TITLE
Fix #298, rigidly specified unique codec config

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1613,6 +1613,7 @@ This section specifies the conformance points of the simple profile.
 Restrictions on the IA sequence:
 
 - There shall be only one unique Codec Config OBU.
+	- It shall be still unique if it only varies by redundant_flag.
 - There shall be only one unique Audio Element OBU.
 - There shall be only one unique set of Descriptor OBUs.
 - There shall be only one Sync OBU placed immediately after each set of Descriptor OBUs, and no additional new Sync OBUs inserted anywhere in the sequence of data OBUs that follow.
@@ -1638,6 +1639,7 @@ This section specifies the conformance points of the base profile.
 
 Restrictions on IA sequence:
 - There shall be only one unique Codec Config OBU.
+	- It shall be still unique if it only varies by redundant_flag.
 - There shall be at most two unique Audio Element OBUs at any one time.
 	- There shall be at most one Channel-based Audio Element having [=num_layers=] > 1 at any one time.
 	- There shall be at most one Scene-based Audio Element at any one time.

--- a/index.bs
+++ b/index.bs
@@ -1605,6 +1605,7 @@ For IAMF-LPCM, one Substream is an individual channel of input audio. For exampl
 
 The IA Profiles define a set of capabilities that are required to parse, decode and process the corresponding IA sequence.
 
+NOTE: In this section and subsections, the meaning of an unique OBU is that it is still unique if it only varies by reduntant flag.
 
 ## IA Simple Profile ## {#profiles-simple}
 
@@ -1613,7 +1614,6 @@ This section specifies the conformance points of the simple profile.
 Restrictions on the IA sequence:
 
 - There shall be only one unique Codec Config OBU.
-	- It shall be still unique if it only varies by redundant_flag.
 - There shall be only one unique Audio Element OBU.
 - There shall be only one unique set of Descriptor OBUs.
 - There shall be only one Sync OBU placed immediately after each set of Descriptor OBUs, and no additional new Sync OBUs inserted anywhere in the sequence of data OBUs that follow.
@@ -1639,7 +1639,6 @@ This section specifies the conformance points of the base profile.
 
 Restrictions on IA sequence:
 - There shall be only one unique Codec Config OBU.
-	- It shall be still unique if it only varies by redundant_flag.
 - There shall be at most two unique Audio Element OBUs at any one time.
 	- There shall be at most one Channel-based Audio Element having [=num_layers=] > 1 at any one time.
 	- There shall be at most one Scene-based Audio Element at any one time.


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/pull/317.html" title="Last updated on Mar 14, 2023, 1:37 AM UTC (7157882)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/317/4621c48...7157882.html" title="Last updated on Mar 14, 2023, 1:37 AM UTC (7157882)">Diff</a>