### PR TITLE
Fix #326, semantic of obu_size

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -540,7 +540,7 @@ This flag shall be set to 0 for the current version of the specification (i.e. [
 
 NOTE: A future version of specification may use this flag to specify an extension header field by setting [=obu_extension_flag=] = 1 and setting the size of extended header to [=extension_header_size=].
 
-<dfn noexport>obu_size</dfn> indicates the size in bytes of the OBU immediately following the obu _size field of the OBU.
+<dfn noexport>obu_size</dfn> indicates the size in bytes of the OBU immediately following the obu_size field of the OBU.
 	
 <dfn noexport>num_samples_to_trim_at_start</dfn> indicates the number of samples that needs to be trimmed from the start of the samples in this Audio Frame OBU. 
 

--- a/index.bs
+++ b/index.bs
@@ -540,8 +540,8 @@ This flag shall be set to 0 for the current version of the specification (i.e. [
 
 NOTE: A future version of specification may use this flag to specify an extension header field by setting [=obu_extension_flag=] = 1 and setting the size of extended header to [=extension_header_size=].
 
-<dfn noexport>obu_size</dfn> indicates the size in bytes of the OBU not including the bytes within the obu_header of the preceding fields, i.e. obu_type, obu_redundant_copy, obu_trimming_status_flag and obu_extension_flag.
-
+<dfn noexport>obu_size</dfn> indicates the size in bytes of the OBU immediately following the obu _size field of the OBU.
+	
 <dfn noexport>num_samples_to_trim_at_start</dfn> indicates the number of samples that needs to be trimmed from the start of the samples in this Audio Frame OBU. 
 
 <dfn noexport>num_samples_to_trim_at_end</dfn> indicates the number of samples that needs to be trimmed from the end of the samples in this Audio Frame OBU.
@@ -573,8 +573,6 @@ The reserved OBU allows the extension of this specification with additional OBU 
 ### Magic Code OBU Syntax and Semantics ### {#obu-magiccode}
 
 This section specifies obu payload of OBU_IA_Magic_Code.
-
-For this obu, the obu header (2 bytes) shall be set to 0xF807 (in case of [=obu_redundant_copy=] = 0) or FC07 (in case of [=obu_redundant_copy=] = 1) for this version of the specification.
 
 <b>Syntax</b>
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/pull/327.html" title="Last updated on Mar 15, 2023, 4:01 PM UTC (bfb07ae)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/327/d055820...bfb07ae.html" title="Last updated on Mar 15, 2023, 4:01 PM UTC (bfb07ae)">Diff</a>