### PR TITLE
Fix #330, to clarify definition of relative offset in sync OBU

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1100,7 +1100,10 @@ For this version of the specification, the value of reinitialize_decoder shall b
 
 <dfn noexport>relative_offset</dfn> is the offset to position the first audio frame (before trimming) or parameter block with the referenced obu_id that comes after this Sync OBU with respect to the timeline generated before this Sync OBU. If this Sync OBU is the first one, it is the offset from 0. Otherwise, it is the offset from the end of the timeline of Substreams generated from the previous Sync OBU.
 
-The offset shall be indicated in the number of ticks at the [=parameter_rate=] specified in the corresponding substream or parameter definition.
+The difference, [=relative_offset=](P) - [=relative_offset=](A), shall be the offset to position the first audio sample where the first parameter value of the first parameter block that comes after this Sync OBU is applied to.
+- Where, [=relative_offset=](P) is [=relative_offset=] of [=obu_id=] for the parameter and [=relative_offset=](A) is [=relative_offset=] of [=obu_id=] for the substream which the parameter is applied to. 
+
+The offset shall be indicated in the number of ticks at the sample rate specified in the corresponding substream or Codec Config OBU. For IAMF-OPUS, the sample rate is 48000Hz.
 
 IA encoder and decoder operations related to this field are specified in [[#standalone-synchronizing-data-obus]].
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/pull/331.html" title="Last updated on Mar 27, 2023, 11:10 PM UTC (c7fd867)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/331/ddaee5c...c7fd867.html" title="Last updated on Mar 27, 2023, 11:10 PM UTC (c7fd867)">Diff</a>