### PR TITLE
Fix #335, clarified decoder config for OPUS

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -84,6 +84,8 @@ url: https://tools.ietf.org/html/rfc8486#; spec: RFC8486; type: dfn;
 
 url: https://tools.ietf.org/html/rfc7845#; spec: RFC7845; type: dfn;
 	text: ID Header
+	text: Magic Signature
+	text: Output Channel Count
 	text: Output Gain
 	text: Pre-skip
 
@@ -1578,8 +1580,9 @@ For legacy codecs, Decoder_Config() shall be exactly the same information as the
 
 [=Codec_ID=] shall be 'Opus'.
 
-Codec_Specific_Info for IAMF-OPUS conforms to [=ID Header=] with [=ChannelMappingFamily=] = 0 of [[!RFC7845]] with following constraints:
-- [=Channel Count=] must be set to 2. [=Channel Count=] can be ignored because the real value can be determined from the Audio Element OBU and from the opus packet header.
+[=Decoder_Config()=] for IAMF-OPUS conforms to [=ID Header=] with [=ChannelMappingFamily=] = 0 of [[!RFC7845]] with following constraints:
+- [=Magic Signature=] shall not be present.
+- [=Output Channel Count=] must be set to 2. [=Output Channel Count=] can be ignored because the real value can be determined from the Audio Element OBU and from the opus packet header.
 - [=Pre-skip=] shall be same as the number of audio samples to be trimmed at the start of substreams.
 - [=Output Gain=] shall not be used. In other words, it shall be set to 0dB.
 - The byte order of each field in [=ID Header=] is converted to big endian.


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/pull/336.html" title="Last updated on Mar 27, 2023, 7:25 AM UTC (bf4e317)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/336/ddaee5c...bf4e317.html" title="Last updated on Mar 27, 2023, 7:25 AM UTC (bf4e317)">Diff</a>