### PR TITLE
Fix #157, restructured OBU syntax sections

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1506,8 +1506,6 @@ This value must be greater or equal to 22, in order to avoid collision with the 
 
 For IAMF-LPCM, [=audio_frame()=] shall be LPCM samples. When more than one byte is used to represent a LPCM sample, the byte order is in little endian. 
 
-For this version of the specification, all audio frames for a given substream must be gapless.
-
 ## Temporal Delimiter OBU Syntax and Semantics ## {#obu-temporaldelimiter}
 
 This section specifies the OBU payload of OBU_IA_Temporal_Delimiter.

--- a/index.bs
+++ b/index.bs
@@ -788,13 +788,14 @@ abstract class ParamDefinition() {
 
 <dfn noexport>constant_segment_interval</dfn> specifies the interval of each segment, in the case where all segments except the last segment have equal intervals. If all segments except the last segment do not have equal intervals, the value of constant_segment_interval shall be set to 0. 
 
+When it defines <dfn noexport>D</dfn> = the value of [=duration=], <dfn noexport>NS</dfn> = the value of [=num_segments=], <dfn noexport>CSI</dfn> = the value of [=constant_segment_interval=] and <dfn noexport>SI</dfn> = the value of [=segment_interval=].
+- When [=CSI=] != 0, [=NS=] x [=CSI=] shall be equal to or greater than [=D=].
+	- If [=NS=] x [=CSI=] > [=D=], the actual interval of the last segment shall be [=D=] - ([=NS=] - 1) x [=CSI=].
+- When [=CSI=] = 0, the summation of all [=SI=]s in this parameter block shall be equal to [=D=].
+
 <dfn noexport>segment_interval</dfn> specifies the interval for the given segment.
 
 Each value of [=duration=], [=constant_segment_interval=] and [=segment_interval=] shall be expressed as the number of ticks at the [=parameter_rate=] specified in the corresponding parameter definition.
-- When it defines <dfn noexport>D</dfn> = the value of [=duration=], <dfn noexport>NS</dfn> = the value of [=num_segments=], <dfn noexport>CSI</dfn> = the value of [=constant_segment_interval=] and <dfn noexport>SI</dfn> = the value of [=segment_interval=].
-	- When [=CSI=] != 0, [=NS=] x [=CSI=] shall be equal to or greater than [=D=].
-		- If [=NS=] x [=CSI=] > [=D=], the actual interval of the last segment shall be [=D=] - ([=NS=] - 1) x [=CSI=].
-	- When [=CSI=] = 0, the summation of all [=SI=]s in this parameter block shall be equal to [=D=].
 
 ### Scalable Channel Layout Config Syntax and Semantics ### {#syntax-scalable-channel-layout-config}
 

--- a/index.bs
+++ b/index.bs
@@ -445,13 +445,11 @@ In the above figure,
 
 # Open Bitstream Unit (OBU) Syntax and Semantics # {#obu-syntax}
 
-## Top Level OBU Syntax and Semantics ## {#top-level-syntax}
-
 The IA sequence uses the OBU syntax.
 
-This section specifies the top-level OBU syntax elements and their semantics.
+This section specifies the OBU syntax elements and their semantics.
 
-### Audio OBU Syntax and Semantics ### {#audio-obu}
+## Audio OBU Syntax and Semantics ## {#audio-obu}
 
 <b>Syntax</b>
 
@@ -489,7 +487,7 @@ class audio_open_bitstream_unit() {
 If the syntax element obu_type is equal to OBU_IA_Magic_Code, an ordered series of OBUs is presented to the decoding process as a string of bytes.
 
 
-### OBU Header Syntax and Semantics ### {#obu-header}
+## OBU Header Syntax and Semantics ## {#obu-header}
 
 <b>Syntax</b>
 
@@ -560,7 +558,7 @@ NOTE: A future version of specification may use this flag to specify an extensio
 <dfn noexport>extension_header_size</dfn> indicates the size in bytes of the extension header including this field.
 
 
-### Byte Alignment Syntax and Semantics ### {#obu-bytealignment}
+## Byte Alignment Syntax and Semantics ## {#obu-bytealignment}
 
 <b>Syntax</b>
 
@@ -576,12 +574,12 @@ class byte_alignment() {
 <dfn noexport>zero_bit</dfn> shall be equal to 0 and is inserted into the bitstream to align the bit position to a multiple of 8 bits.
 
 
-### Reserved OBU Syntax and Semantics ### {#obu-reserved}
+## Reserved OBU Syntax and Semantics ## {#obu-reserved}
 
 The reserved OBU allows the extension of this specification with additional OBU types in a way that allows IAMF-OBU parsers compliant to this version of specification to ignore them.
 
 
-### Magic Code OBU Syntax and Semantics ### {#obu-magiccode}
+## Magic Code OBU Syntax and Semantics ## {#obu-magiccode}
 
 This section specifies obu payload of OBU_IA_Magic_Code.
 
@@ -597,14 +595,14 @@ class magic_code_obu() {
 
 <b>Semantics</b>
 
-<dfn noexport>ia_code</dfn> indicates a ‘four-character code’ (4CC) to identify the start of the IA sequence. It shall be 'iamf'.
+<dfn noexport>ia_code</dfn> indicates a ‘four-character code’ (4CC) to identify the start of the IA sequence. It shall be ‘iamf’.
 
 <dfn noexport>version</dfn> indicates the version of an IA sequence. It shall be set to 0 for this version of the specification. Implementations should treat IA sequences where the MSB four bits of the version number match that of a recognized specification as backwards compatible with that specification. That is, the version number can be split into "major" and "minor" version sub-fields, with changes to the minor sub-field (in the LSB four bits) signaling compatible changes. For example, an implementation of this specification should accept any stream with a version number of ’15’ or less, and should assume any stream with a version number ’16’ or
 greater is incompatible.
 
 <dfn noexport>profile_version</dfn> indicates the profile of an IA sequence. The MSB four bits indicates the profile of an IA sequence. Implementations should treat IA sequences where the MSB four bits of the version number match that of a recognized profile as backwards compatible with that specification. That is, the version number can be split into "profile major" and "profile minor" version sub-fields, with changes to the minor sub-field (in the LSB four bits) signaling compatible changes with the profile major version. The semantic of this field is only valid when the MSB four bits of [=version=] = 0.
 
-### Codec Config OBU Syntax and Semantics ### {#obu-codecconfig}
+## Codec Config OBU Syntax and Semantics ## {#obu-codecconfig}
 
 This section specifies the OBU payload of OBU_IA_Codec_Config.
 
@@ -641,7 +639,7 @@ class codec_config() {
 - The codec_id and decoder_config() for IAMF-FLAC shall conform to [=Codec_Specific_Info=] of [[#iamf-flac-specific]]
 - The codec_id and decoder_config() for IAMF-LPCM shall conform to [=Codec_Specific_Info=] of [[#iamf-lpcm-specific]].
 
-### Audio Element OBU Syntax and Semantics ### {#obu-audioelement}
+## Audio Element OBU Syntax and Semantics ## {#obu-audioelement}
 
 This section specifies the OBU payload of OBU_IA_Audio_Element.
 
@@ -748,218 +746,9 @@ A ChannelGroup is defined in [[#iamfgeneration]]. The order of the substreams in
 
 <dfn noexport>ambisonics_config()</dfn> is a class that provides the metadata required for combining the substreams identified here in order to reconstruct an Ambisonics layout.
 
-### Mix Presentation OBU Syntax and Semantics ### {#obu-mixpresentation}
+### Parameter Definition Syntax and Semantics ### {#parameter-definition}
 
-This section specifies the OBU payload of OBU_IA_Mix_Presentation.
-
-The metadata in mix_presentation() specifies how to render, process and mix one or more audio elements, with details provided in [[#processing-mixpresentation]].
-
-An IA sequence may have one or more mix presentations specified. The IA parser shall select the appropriate mix presentation to process according to the rules specified in [[#processing-mixpresentation-selection]].
-
-A mix presentation may contain one or more sub-mixes. Common use-cases may specify only one sub-mix, which includes all rendered and processed audio elements used in the mix presentation. The use-case for specifying more than one sub-mix arises if an IA multiplexer is merging two or more IA sequences. In this case, it may choose to capture the loudness information from the original IA sequences in multiple sub-mixes, instead of recomputing the loudness information for the final mix.
-
-<b>Syntax</b>
-```
-class mix_presentation_obu() {
-  leb128() mix_presentation_id;
-  mix_presentation_annotations();
-
-  leb128() num_sub_mixes;
-  for (i = 0; i < num_sub_mixes; i++) {	  
-    leb128() num_audio_elements;
-    for (j = 0; j < num_audio_elements; j++) {
-      leb128() audio_element_id;
-      mix_presentation_element_annotations();
-      rendering_config();
-      element_mix_config();
-    }
-    output_mix_config();
-    
-    leb128() num_layouts;
-    for (j = 0; j < num_layouts; j++) {
-      layout loudness_layout;
-      loudness_info loudness; 
-    }
-  }
-}  
-```
-
-<b>Semantics</b>
-
-<dfn noexport>mix_presentation_id</dfn> indicates an unique obu_id with [=obu_type=] = OBU_IA_Mix_Presentation in IA sequences for a given mix presentation.
-
-<dfn noexport>mix_presentation_annotations()</dfn> is a class that provides informational metadata that an IA parser should refer to when selecting the mix presentation to use. The metadata may also be used by the playback system to display information to the user, but is not used in the rendering or mixing process to generate the final output audio signal.
-
-<dfn noexport>num_sub_mixes</dfn> specifies the number of sub-mixes.
-
-<dfn noexport>num_audio_elements</dfn> specifies the number of audio elements that are used in this mix presentation to generate the final output audio signal for playback.
-
-<dfn value noexport for ="mix_presentation_obu()">audio_element_id</dfn> indicates the obu_id associated with a specific audio element that is used in this mix presentation.
-
-<dfn noexport>rendering_config()</dfn> is a class that provides the metadata required for rendering the referenced audio element. 
-
-<dfn noexport>element_mix_config()</dfn> is a class that provides the metadata required for applying any processing to the referenced and rendered audio element before being summed with other processed audio elements.
-
-<dfn noexport>output_mix_config()</dfn> is a class that provides the metadata required for post-processing the mixed audio signal to generate the audio signal for playback.
-
-<dfn noexport>num_layouts</dfn> specifies the number of layouts for this sub-mix which the loudness informations were measured on.
-
-<dfn noexport>loudness_layout</dfn> identifies the layout that was used to measure the loudness information provided in this sub-mix.
-
-<dfn noexport>loudness</dfn> provides the loudness information which was measured on [=loudness_layout=] for the mixed audio elements by this sub-mix.
-
-The layout specified in [=loudness_layout=] should not be higher than the highest layout among layouts provided by the audio elements. In other words, rendering from an audio element with the highest layout to the [=loudness_layout=] should not require an upmix.
-
-If one sub-mix of Mix Presentation OBU includes only one single scalable channel audio, then it complies with as follows:
-- [=num_layouts=] shall be greater than or equal to [=num_layers=] specified in [=scalable_channel_layout_config()=] of Audio Element OBU for the [=audio_element_id=].
-- The set of [=loudness_layout=]s shall include all of [=loudspeaker_layout=]s specified in the [=channel_audio_layer_config()=]s of Audio Element OBU for the [=audio_element_id=]. 
-
-The highest [=loudness_layout=] specified in one sub-mix is the layout which was used for authoring the sub-mix.
-
-Each sub-mix shall include [=loudness_layout=] to identify [=Loudspeaker configuration for Sound System A (0+2+0)=] (i.e. Stereo). In other words, each sub-mix shall include [=loudness_info()=] for Stereo. 
-
-#### Mix Presentation Annotations Syntax and Semantics #### {#obu-mixpresentation-annotation}
-
-<b>Syntax</b>
-```
-class mix_presentation_annotations() {
-  string mix_presentation_friendly_label;
-}
-```
-
-<b>Semantics</b>
-
-<dfn noexport>mix_presentation_friendly_label</dfn> specifies a human-friendly label to describe this mix presentation.
-
-
-#### Mix Presentation Element Annotations Syntax and Semantics #### {#obu-mixpresentation-elementannotation}
-
-<b>Syntax</b>
-```
-class mix_presentation_element_annotations() {
-  string audio_element_friendly_label;
-}
-```
-
-<b>Semantics</b>
-
-<dfn noexport>audio_element_friendly_label</dfn> specifies a human-friendly label to describe the referenced audio element.
-
-#### Output Mix Config Syntax and Semantics #### {#obu-mixpresentation-outputmix}
-
-output_mix_config() provides a gain value to be applied to the mixed audio signal.
-
-<b>Syntax</b>
-
-```
-class output_mix_config() {
-  MixGainParamDefinition output_mix_gain;
-}
-```
-
-<b>Semantics</b>
-
-<dfn noexport>output_mix_gain</dfn> provides the parameter definition for the gain value that is applied to all channels of the mixed audio signal. The parameter definition is provided by MixGainParamDefinition() and the corresponding parameter data to be provided in parameter blocks is specified in mix_gain_parameter_data().
-
-#### Loudness Info Syntax and Semantics #### {#obu-mixpresentation-loudness}
-
-loudness_info() provides loudness information for a given audio signal.
-
-All signed values are stored as signed Q7.8 fixed-point values (in [[!Q-Format]]).
-
-<b>Syntax</b>
-
-```
-class loudness_info() {
-  unsigned int (8) info_type;
-  signed int (16) integrated_loudness;
-  signed int (16) digital_peak;
-
-  if (info_type & 1) {
-    signed int (16) true_peak;
-  }
-}
-```
-
-<b>Semantics</b>
-
-<dfn noexport>info_type</dfn> is a bitmask that specifies the type of optional loudness information provided. The bits are set as follows, where the first bit is the LSB:
-
-<pre class = "def">
- Bit : Type of information provided
-  0  : True peak
- 1~7 : Reserved
-</pre>
-
-<dfn noexport>integrated_loudness</dfn> provides the integrated loudness information, specified in [=LKFS=] as defined in [[!ITU1770-4]], and measured according to [[!ITU1770-4]].
-
-<dfn noexport>digital_peak</dfn> specifies the digital (sampled) peak value of the audio signal, specified in dBFS.
-
-<dfn noexport>true_peak</dfn> specifies the true peak of the audio signal, specified in dBFS and measured according to [[!ITU1770-4]].
-
-NOTE: [[!ITU1770-4]] adopts the convention of using the dBov unit for dBFS, where the RMS value of a full-scale square wave is 0 dBov. The same convention is adopted here.
-
-### Parameter Block OBU Syntax and Semantics ### {#obu-parameterblock}
-
-This section specifies the OBU payload of OBU_IA_Parameter_Block.
-
-The metadata specified in this OBU defines the parameter values for an algorithm for an indicated duration, including any animation of the parameter values over this duration. The metadata are used in conjunction with a corresponding parameter definition and parameter data specification. The parameter definition is specified based on [=ParamDefinition()=]. The parameter data provides the values to apply in each parameter block. These are specified using the [=AnimatedParameterData()=] function template if parameter animation is supported.
-
-<b>Syntax</b>
-
-```
-class parameter_block_obu() {
-  leb128() parameter_id;
-  
-  (param_definition_type, param_definition_mode, duration, num_segments, constant_segment_interval, segment_interval) = get_param_definition(parameter_id);
-  
-  if (param_definition_mode) {
-    leb128() duration;
-    leb128() num_segments;
-    leb128() constant_segment_interval;
-  }
-
-  for (i = 0; i < num_segments; i++) {
-    if (param_definition_mode) {
-      if (constant_segment_interval == 0) {
-        leb128() segment_interval;
-      }
-    }
-
-    if (param_definition_type == PARAMETER_DEFINITION_MIX_GAIN) {
-      mix_gain_parameter_data();
-    }
-    if (param_definition_type == PARAMETER_DEFINITION_DEMIXING) {
-      demixing_info_parameter_data();
-    }
-    if (param_definition_type == PARAMETER_DEFINITION_RECON_GAIN) {
-      recon_gain_info_parameter_data();
-    }
-  }
-}
-```
-
-<b>Semantics</b>
-
-<dfn noexport>parameter_id</dfn> indicates an unique obu_id with [=obu_type=] = OBU_IA_Parameter_Block that is associated with a specific parameter definition. All parameter blocks that provide data for that parameter definition shall have the same parameter_id.
-
-<dfn noexport>get_param_definition()</dfn> is a run-time function to get the parameter definition type, the parameter definition mode, duration, num_segments, constant_segment_interval and segment_interval mapped to the parameter_id. 
-
-<dfn value noexport for="parameter_block_obu()">duration</dfn> specifies the duration for which this parameter block is valid and applicable. 
-
-<dfn value noexport for="parameter_block_obu()">num_segments</dfn> specifies the number of different sets of parameter values specified in this parameter block, where each set describes a different segment of the timeline, contiguously.
-
-<dfn value noexport for="parameter_block_obu()">constant_segment_interval</dfn> specifies the interval of each segment, in the case where all segments except the last segment have equal intervals. If all segments except the last segment do not have equal intervals, the value of constant_segment_interval shall be set to 0. 
-
-Audio Element OBU and/or Mix Presentation OBU is mapping a parameter_id to the parameter definition type. So, IA decoders can know the definition type mapped to the parameter_id.
-
-<dfn value noexport for="parameter_block_obu()">segment_interval</dfn> specifies the interval for the given segment.
-
-Each value of duration, constant_segment_interval and segment_interval shall be expressed as the number of ticks at the [=parameter_rate=] specified in the corresponding parameter definition.
-
-#### Parameter Definition Syntax and Semantics #### {#parameter-definition}
-
-Parameter definition classes inherits from the abstract <dfn noexport>ParamDefinition()</dfn> class. They may optionally further provide default parameter values, which are applied when there are no parameter blocks available.
+Parameter definition classes inherits from the abstract <dfn noexport>ParamDefinition()</dfn> class.
 
 <b>Syntax</b>
 
@@ -1006,115 +795,6 @@ Each value of [=duration=], [=constant_segment_interval=] and [=segment_interval
 	- When [=CSI=] != 0, [=NS=] x [=CSI=] shall be equal to or greater than [=D=].
 		- If [=NS=] x [=CSI=] > [=D=], the actual interval of the last segment shall be [=D=] - ([=NS=] - 1) x [=CSI=].
 	- When [=CSI=] = 0, the summation of all [=SI=]s in this parameter block shall be equal to [=D=].
-
-### Audio Frame OBU Syntax and Semantics ### {#obu-audioframe}
-
-This section specifies OBU payloads of OBU_IA_Audio_Frame and OBU_IA_Audio_Frame_ID0 to OBU_IA_Audio_Frame_ID21. 
-
-The first 22 audio substreams in an IA sequence may use the OBU types OBU_IA_Audio_Frame_ID0 to OBU_IA_Audio_Frame_ID21, which have predefined audio substream obu_ids associated with them. This avoids the need to manually specify an [=audio_substream_id=].
-
-[=audio_substream_id=] = 0 to [=audio_substream_id=] = 21 shall be assigned to Audio Frame OBUs with the OBU types OBU_IA_Audio_Frame_ID0 to OBU_IA_Audio_Frame_ID21, respectively. 
-
-<b>Syntax</b>
-
-```
-class audio_frame_obu_with_no_id() {
-  leb128() audio_substream_id;
-  audio_frame_obu(audio_substream_id);
-}
-```
-
-```
-class audio_frame_obu() {
-  unsigned int (8*coded_frame_size) audio_frame();
-}
-```
-
-<b>Semantics</b>
-
-<dfn noexport>audio_substream_id</dfn> indicates an unique obu_id with [=obu_type=] = OBU_IA_Audio_Frame in IA sequences for a given substream. All Audio Frame OBUs of the same substream shall have the same audio_substream_id.
-
-This value must be greater or equal to 22, in order to avoid collision with the reserved IDs for the OBU types OBU_IA_Audio_Frame_ID0 to OBU_IA_Audio_Frame_ID21.
-
-<dfn noexport>coded_frame_size</dfn> is the size of [=audio_frame()=] in bytes.
-
-<dfn noexport>audio_frame()</dfn> is the raw coded audio data for the frame. It shall be [=opus packet=] of [[!RFC6716]] for IAMF-OPUS, [=raw_data_block()=] of [[!AAC]] for IAMF-AAC-LC and [=FRAME=] of [[!FLAC]] for IAMF-FLAC.
-
-For IAMF-LPCM, [=audio_frame()=] shall be LPCM samples. When more than one byte is used to represent a LPCM sample, the byte order is in little endian. 
-
-For this version of the specification, all audio frames for a given substream must be gapless.
-
-### Temporal Delimiter OBU Syntax and Semantics ### {#obu-temporaldelimiter}
-
-This section specifies the OBU payload of OBU_IA_Temporal_Delimiter.
-
-<b>Syntax</b>
-
-```
-class temporal_delimiter_obu() {
-}
-```
-
-NOTE: The Temporal Delimiter OBU has an empty payload.
-
-### Sync OBU Syntax and Semantics ### {#obu-sync}
-
-This section specifies the OBU payload of OBU_IA_Sync.
-
-<b>Syntax</b>
-
-```
-class sync_obu() {
-  leb128() global_offset;
-  leb128() num_obu_ids;
-  for (i = 0; i < num_obu_ids; i++) {
-    leb128() obu_id;
-    unsigned int (1) obu_data_type;
-    unsigned int (1) reinitialize_decoder;
-    unsigned int (6) reserved;
-    sleb128() relative_offset;
-  }
-}
-```
-
-<b>Semantics</b>
-
-<dfn noexport>global_offset</dfn> specifies the offset that is applied to all substreams and parameters specified in this Sync OBU, in addition to their individual relative offsets.
-
-For this version of the specification, the value of global_offset shall be set to 0.
-
-<dfn noexport>num_obu_ids</dfn> specifies the number of substream and parameter IDs that this Sync OBU specifies the offset for.
-
-<dfn noexport>obu_id</dfn> specifies the unique ID associated with the substream or parameter that is being referred to.
-
-<dfn noexport>obu_data_type</dfn> specifies the type of data that is being referred to.
-
-<pre class = "def">
-obu_data_type : Type of OBU data
-      0       : SUBSTREAM
-      1       : PARAMETER
-</pre>
-
-<dfn noexport>reinitialize_decoder</dfn> is used to specify the behaviour of a decoder when encountering gaps in the audio substream, where the gap is identified as described in [[#standalone-synchronizing-data-obus]]. If obu_data_type does not equal SUBSTREAM, an IAMF-OBU parser shall ignore this field.
-
-If reinitialize_decoder = 0, the decoder shall not be reinitialized before decoding the audio frames after the gap. This may be used in the case where it is preferable for the decoder to fill the gap with silence instead.
-
-If reinitialize_decoder = 1, the decoder shall be reinitialized before decoding the audio frames after the gap. If a pre-skip is specified in the relevant Codec Config OBU, it is applicable after reinitializing the decoder.
-
-For this version of the specification, the value of reinitialize_decoder shall be set to 0. If a value of 1 is seen, the IA sequence shall be rejected as invalid.
-
-<dfn value noexport for="sync_obu()">reserved</dfn> shall be set to 0. Reserved units are for future use and shall be ignored by an IAMF-OBU parser.
-
-<dfn noexport>relative_offset</dfn> is the offset to position the first audio frame (before trimming) or parameter block with the referenced obu_id that comes after this Sync OBU with respect to the timeline generated before this Sync OBU. If this Sync OBU is the first one, it is the offset from 0. Otherwise, it is the offset from the end of the timeline of Substreams generated from the previous Sync OBU.
-
-The difference, [=relative_offset=](P) - [=relative_offset=](A), shall be the offset to position the first audio sample where the first parameter value of the first parameter block that comes after this Sync OBU is applied to.
-- Where, [=relative_offset=](P) is [=relative_offset=] of [=obu_id=] for the parameter and [=relative_offset=](A) is [=relative_offset=] of [=obu_id=] for the substream which the parameter is applied to. 
-
-The offset shall be indicated in the number of ticks at the sample rate specified in the corresponding substream or Codec Config OBU. For IAMF-OPUS, the sample rate is 48000Hz.
-
-IA encoder and decoder operations related to this field are specified in [[#standalone-synchronizing-data-obus]].
-
-## Detailed OBU Syntax and Semantics ## {#syntax-detailed}
 
 ### Scalable Channel Layout Config Syntax and Semantics ### {#syntax-scalable-channel-layout-config}
 
@@ -1288,71 +968,157 @@ If ambisonics_mode is equal to PROJECTION, this indicates that the Ambisonics ch
 <dfn noexport>demixing_matrix</dfn> complies with the one for [=ChannelMappingFamily=] = 3 in [[!RFC8486]] except the byte order of each of matrix coefficients is converted to big endian.
 
 
-### Demixing Info Parameter Data Syntax and Semantics ### {#syntax-demixing-info}
+## Mix Presentation OBU Syntax and Semantics ## {#obu-mixpresentation}
 
-<dfn noexport>demixing_info_parameter_data()</dfn> specifies demixing parameter mode to be used to reconstruct output channel audio according to its [=loudspeaker_layout=].
+This section specifies the OBU payload of OBU_IA_Mix_Presentation.
 
-<b>Syntax</b>
+The metadata in mix_presentation() specifies how to render, process and mix one or more audio elements, with details provided in [[#processing-mixpresentation]].
 
-```
-class demixing_info_parameter_data() {
-  unsigned int (3) dmixp_mode;
-  unsigned int (5) reserved;
-}
-```
+An IA sequence may have one or more mix presentations specified. The IA parser shall select the appropriate mix presentation to process according to the rules specified in [[#processing-mixpresentation-selection]].
 
-<b>Semantics</b>
-
-<dfn noexport>dmixp_mode</dfn> indicates a mode of pre-defined combinations of five demix parameters.
-- 0: mode1, (alpha, beta, gamma, delta, w_idx_offset) = (1, 1, 0.707, 0.707, -1)
-- 1: mode2, (alpha, beta, gamma, delta, w_idx_offset) = (0.707, 0.707, 0.707, 0.707, -1)
-- 2: mode3, (alpha, beta, gamma, delta, w_idx_offset) = (1, 0.866, 0.866, 0.866, -1)
-- 3: reserved
-- 4: mode1, (alpha, beta, gamma, delta, w_idx_offset) = (1, 1, 0.707, 0.707, 1)
-- 5: mode2, (alpha, beta, gamma, delta, w_idx_offset) = (0.707, 0.707, 0.707, 0.707, 1)
-- 6: mode3, (alpha, beta, gamma, delta, w_idx_offset) = (1, 0.866, 0.866, 0.866, 1)
-- 7: reserved
-
-<dfn noexport>alpha</dfn> and <dfn noexport>beta</dfn> are gain values used for S7to5 down-mixer, <dfn noexport>gamma</dfn> for T4to2 down-mixer, <dfn noexport>delta</dfn> for S5to3 down-mixer and <dfn noexport>w_idx_offset</dfn> is the offset to generate a gain value <dfn noexport>w</dfn> used for T2toTF2 down-mixer.
-
-<center><img src="images/Down-mix Mechanism.png" style="width:100%; height:auto;"></center>
-<center><figcaption></b>IA Down-mix Mechanism</figcaption></center>
-
-### Recon Gain Info Parameter Data Syntax and Semantics ### {#syntax-recon-gain-info}
-
-<dfn noexport>recon_gain_info_parameter_data()</dfn> contains recon gain values for demixed channels.
-
-NOTE: [=recon_gain_info_parameter_data()=] is required to compensate the propagated errors by De-mixer and Gain modules specified in [[#processing-scalablechannelaudio-demixer]] and [[#processing-scalablechannelaudio-gain]] due to the error caused by lossy codecs such as IAMF-OPUS and IAMF-AAC-LC. However, it is not required for lossless codecs such as IAMF-FLAC and IAMF-LPCM because the propagated errors are negligible.
+A mix presentation may contain one or more sub-mixes. Common use-cases may specify only one sub-mix, which includes all rendered and processed audio elements used in the mix presentation. The use-case for specifying more than one sub-mix arises if an IA multiplexer is merging two or more IA sequences. In this case, it may choose to capture the loudness information from the original IA sequences in multiple sub-mixes, instead of recomputing the loudness information for the final mix.
 
 <b>Syntax</b>
-
 ```
-class recon_gain_info_parameter_data() {
-  for (i=0; i< num_layers; i++) {
-    if (recon_gain_is_present_flag(i) == 1) {
-      leb128() recon_gain_flags(i);
-      for (j=0; j< n(i); j++) {
-        if (recon_gain_flag(i)(j) == 1)
-          unsigned int (8) recon_gain;
-      }
+class mix_presentation_obu() {
+  leb128() mix_presentation_id;
+  mix_presentation_annotations();
+
+  leb128() num_sub_mixes;
+  for (i = 0; i < num_sub_mixes; i++) {	  
+    leb128() num_audio_elements;
+    for (j = 0; j < num_audio_elements; j++) {
+      leb128() audio_element_id;
+      mix_presentation_element_annotations();
+      rendering_config();
+      element_mix_config();
+    }
+    output_mix_config();
+    
+    leb128() num_layouts;
+    for (j = 0; j < num_layouts; j++) {
+      layout loudness_layout;
+      loudness_info loudness; 
     }
   }
+}  
+```
+
+<b>Semantics</b>
+
+<dfn noexport>mix_presentation_id</dfn> indicates an unique obu_id with [=obu_type=] = OBU_IA_Mix_Presentation in IA sequences for a given mix presentation.
+
+<dfn noexport>mix_presentation_annotations()</dfn> is a class that provides informational metadata that an IA parser should refer to when selecting the mix presentation to use. The metadata may also be used by the playback system to display information to the user, but is not used in the rendering or mixing process to generate the final output audio signal.
+
+<dfn noexport>num_sub_mixes</dfn> specifies the number of sub-mixes.
+
+<dfn noexport>num_audio_elements</dfn> specifies the number of audio elements that are used in this mix presentation to generate the final output audio signal for playback.
+
+<dfn value noexport for ="mix_presentation_obu()">audio_element_id</dfn> indicates the obu_id associated with a specific audio element that is used in this mix presentation.
+
+<dfn noexport>rendering_config()</dfn> is a class that provides the metadata required for rendering the referenced audio element. 
+
+<dfn noexport>element_mix_config()</dfn> is a class that provides the metadata required for applying any processing to the referenced and rendered audio element before being summed with other processed audio elements.
+
+<dfn noexport>output_mix_config()</dfn> is a class that provides the metadata required for post-processing the mixed audio signal to generate the audio signal for playback.
+
+<dfn noexport>num_layouts</dfn> specifies the number of layouts for this sub-mix which the loudness informations were measured on.
+
+<dfn noexport>loudness_layout</dfn> identifies the layout that was used to measure the loudness information provided in this sub-mix.
+
+<dfn noexport>loudness</dfn> provides the loudness information which was measured on [=loudness_layout=] for the mixed audio elements by this sub-mix.
+
+The layout specified in [=loudness_layout=] should not be higher than the highest layout among layouts provided by the audio elements. In other words, rendering from an audio element with the highest layout to the [=loudness_layout=] should not require an upmix.
+
+If one sub-mix of Mix Presentation OBU includes only one single scalable channel audio, then it complies with as follows:
+- [=num_layouts=] shall be greater than or equal to [=num_layers=] specified in [=scalable_channel_layout_config()=] of Audio Element OBU for the [=audio_element_id=].
+- The set of [=loudness_layout=]s shall include all of [=loudspeaker_layout=]s specified in the [=channel_audio_layer_config()=]s of Audio Element OBU for the [=audio_element_id=]. 
+
+The highest [=loudness_layout=] specified in one sub-mix is the layout which was used for authoring the sub-mix.
+
+Each sub-mix shall include [=loudness_layout=] to identify [=Loudspeaker configuration for Sound System A (0+2+0)=] (i.e. Stereo). In other words, each sub-mix shall include loudness_info() for Stereo. 
+
+### Mix Presentation Annotations Syntax and Semantics ### {#obu-mixpresentation-annotation}
+
+<b>Syntax</b>
+```
+class mix_presentation_annotations() {
+  string mix_presentation_friendly_label;
 }
 ```
 
 <b>Semantics</b>
 
-<dfn noexport>recon_gain_flags</dfn> indicates the channels which recon_gain is applied to.
+<dfn noexport>mix_presentation_friendly_label</dfn> specifies a human-friendly label to describe this mix presentation.
 
-<left><img src="images/Recon_Gain_Flags.png" style="width:100%; height:auto;"></left>
 
-The each bit of [=recon_gain_flags=] indicates the presence of [=recon_gain=] applied to the channel as depicted in the above figure.
- - 0: It indicates that no [=recon_gain=] presents for the channel.
- - 1: It indicates that [=recon_gain=] presents for the channel.
+### Mix Presentation Element Annotations Syntax and Semantics ### {#obu-mixpresentation-elementannotation}
 
-<dfn noexport>n(i)</dfn> indicates the number of bits for recon_gain_flag(i). It shall be 7 or 12 as depicted in the above figure. Where, i = 0, 1, ..., [=num_layers=] - 1.
+<b>Syntax</b>
+```
+class mix_presentation_element_annotations() {
+  string audio_element_friendly_label;
+}
+```
 
-<dfn noexport>recon_gain</dfn> indicates the gain value to be applied to the channel, which is indicated by [=recon_gain_flags=], after decoding of the associated frames and demixing operation. Where, the channel is indicated by recon_gain_flags. Detailed operation by using this value is specified in [[#processing-scalablechannelaudio-recongain]].
+<b>Semantics</b>
+
+<dfn noexport>audio_element_friendly_label</dfn> specifies a human-friendly label to describe the referenced audio element.
+
+### Rendering Config Syntax and Semantics ### {#syntax-rendering-config}
+
+During playback, an audio element should be rendered using a pre-defined renderer according to [[#processing-mixpresentation-rendering]]. In this version of the specification, no additional metadata is required to configure the renderers, and as such, <code>rendering_config()</code> has an empty payload.
+
+<b>Syntax</b>
+
+```
+class rendering_config() {
+}
+```
+
+<b>Semantics</b>
+
+### Element Mix Config Syntax and Semantics ### {#syntax-element-mix-config}
+
+[=element_mix_config()=] provides a gain value to be applied to the rendered audio element signal.
+
+<b>Syntax</b>
+
+```
+class element_mix_config() {
+  MixGainParamDefinition mix_gain;
+}
+```
+
+```
+class MixGainParamDefinition() extends ParamDefinition() {
+  signed int (16) default_mix_gain;
+}
+```
+
+<b>Semantics</b>
+
+<dfn noexport>mix_gain</dfn> provides the parameter definition for the gain value that is applied to all channels of the rendered audio element signal. The parameter definition is provided by MixGainParamDefinition() and the corresponding parameter data to be provided in parameter blocks is specified in mix_gain_parameter_data().
+
+<dfn noexport>default_mix_gain</dfn> specifies the default mix gain value to apply when there are no mix gain parameter blocks provided. This value is expressed in dB and shall be applied to all channels in the rendered audio element. It is stored as a 16-bit, signed, two's complement fixed-point value with 8 fractional bits (i.e. Q7.8 in [[!Q-Format]]).
+
+
+### Output Mix Config Syntax and Semantics ### {#obu-mixpresentation-outputmix}
+
+output_mix_config() provides a gain value to be applied to the mixed audio signal.
+
+<b>Syntax</b>
+
+```
+class output_mix_config() {
+  MixGainParamDefinition output_mix_gain;
+}
+```
+
+<b>Semantics</b>
+
+<dfn noexport>output_mix_gain</dfn> provides the parameter definition for the gain value that is applied to all channels of the mixed audio signal. The parameter definition is provided by MixGainParamDefinition() and the corresponding parameter data to be provided in parameter blocks is specified in mix_gain_parameter_data().
+
 
 ### Layout Syntax and Semantics ### {#syntax-layout}
 
@@ -1487,44 +1253,107 @@ layout_type : Layout type
  - 11: It indicates the same loudspeaker configuration as [=loudspeaker_layout=] = 1000 (i.e. 3.1.2ch)
  - 12 ~ 15: Reserved
 
-### Rendering Config Syntax and Semantics ### {#syntax-rendering-config}
+### Loudness Info Syntax and Semantics ### {#obu-mixpresentation-loudness}
 
-During playback, an audio element should be rendered using a pre-defined renderer according to [[#processing-mixpresentation-rendering]]. In this version of the specification, no additional metadata is required to configure the renderers, and as such, <code>rendering_config()</code> has an empty payload.
+loudness_info() provides loudness information for a given audio signal.
+
+All signed values are stored as signed Q7.8 fixed-point values (in [[!Q-Format]]).
 
 <b>Syntax</b>
 
 ```
-class rendering_config() {
+class loudness_info() {
+  unsigned int (8) info_type;
+  signed int (16) integrated_loudness;
+  signed int (16) digital_peak;
+
+  if (info_type & 1) {
+    signed int (16) true_peak;
+  }
 }
 ```
 
 <b>Semantics</b>
 
-### Element Mix Config Syntax and Semantics ### {#syntax-element-mix-config}
+<dfn noexport>info_type</dfn> is a bitmask that specifies the type of optional loudness information provided. The bits are set as follows, where the first bit is the LSB:
 
-[=element_mix_config()=] provides a gain value to be applied to the rendered audio element signal.
+<pre class = "def">
+ Bit : Type of information provided
+  0  : True peak
+ 1~7 : Reserved
+</pre>
+
+<dfn noexport>integrated_loudness</dfn> provides the integrated loudness information, specified in [=LKFS=] as defined in [[!ITU1770-4]], and measured according to [[!ITU1770-4]].
+
+<dfn noexport>digital_peak</dfn> specifies the digital (sampled) peak value of the audio signal, specified in dBFS.
+
+<dfn noexport>true_peak</dfn> specifies the true peak of the audio signal, specified in dBFS and measured according to [[!ITU1770-4]].
+
+NOTE: [[!ITU1770-4]] adopts the convention of using the dBov unit for dBFS, where the RMS value of a full-scale square wave is 0 dBov. The same convention is adopted here.
+
+## Parameter Block OBU Syntax and Semantics ## {#obu-parameterblock}
+
+This section specifies the OBU payload of OBU_IA_Parameter_Block.
+
+The metadata specified in this OBU defines the parameter values for an algorithm for an indicated duration, including any animation of the parameter values over this duration. The metadata are used in conjunction with a corresponding parameter definition and parameter data specification. The parameter definition is specified based on [=ParamDefinition()=]. The parameter data provides the values to apply in each parameter block. These are specified using the [=AnimatedParameterData()=] function template if parameter animation is supported.
 
 <b>Syntax</b>
 
 ```
-class element_mix_config() {
-  MixGainParamDefinition mix_gain;
+class parameter_block_obu() {
+  leb128() parameter_id;
+  
+  (param_definition_type, param_definition_mode, duration, num_segments, constant_segment_interval, segment_interval) = get_param_definition(parameter_id);
+  
+  if (param_definition_mode) {
+    leb128() duration;
+    leb128() num_segments;
+    leb128() constant_segment_interval;
+  }
+
+  for (i = 0; i < num_segments; i++) {
+    if (param_definition_mode) {
+      if (constant_segment_interval == 0) {
+        leb128() segment_interval;
+      }
+    }
+
+    if (param_definition_type == PARAMETER_DEFINITION_MIX_GAIN) {
+      mix_gain_parameter_data();
+    }
+    if (param_definition_type == PARAMETER_DEFINITION_DEMIXING) {
+      demixing_info_parameter_data();
+    }
+    if (param_definition_type == PARAMETER_DEFINITION_RECON_GAIN) {
+      recon_gain_info_parameter_data();
+    }
+  }
 }
 ```
 
 <b>Semantics</b>
 
-<dfn noexport>mix_gain</dfn> provides the parameter definition for the gain value that is applied to all channels of the rendered audio element signal. The parameter definition is provided by MixGainParamDefinition() and the corresponding parameter data to be provided in parameter blocks is specified in mix_gain_parameter_data().
+<dfn noexport>parameter_id</dfn> indicates an unique obu_id with [=obu_type=] = OBU_IA_Parameter_Block that is associated with a specific parameter definition. All parameter blocks that provide data for that parameter definition shall have the same parameter_id.
 
-#### Mix Gain Parameter Definition and Data Syntax and Semantics #### {#syntax-mix-gain-param}
+<dfn noexport>get_param_definition()</dfn> is a run-time function to get the parameter definition type, the parameter definition mode, duration, num_segments, constant_segment_interval and segment_interval mapped to the parameter_id. 
+
+<dfn value noexport for="parameter_block_obu()">duration</dfn> specifies the duration for which this parameter block is valid and applicable. 
+
+<dfn value noexport for="parameter_block_obu()">num_segments</dfn> specifies the number of different sets of parameter values specified in this parameter block, where each set describes a different segment of the timeline, contiguously.
+
+<dfn value noexport for="parameter_block_obu()">constant_segment_interval</dfn> specifies the interval of each segment, in the case where all segments except the last segment have equal intervals. If all segments except the last segment do not have equal intervals, the value of constant_segment_interval shall be set to 0. 
+
+Audio Element OBU and/or Mix Presentation OBU is mapping a parameter_id to the parameter definition type. So, IA decoders can know the definition type mapped to the parameter_id.
+
+<dfn value noexport for="parameter_block_obu()">segment_interval</dfn> specifies the interval for the given segment.
+
+Each value of duration, constant_segment_interval and segment_interval shall be expressed as the number of ticks at the [=parameter_rate=] specified in the corresponding parameter definition.
+
+### Mix Gain Parameter Data Syntax and Semantics ### {#syntax-mix-gain-param}
 
 <b>Syntax</b>
 
 ```
-class MixGainParamDefinition extends ParamDefinition() {
-  signed int (16) default_mix_gain;
-}
-
 class mix_gain_parameter_data() {
   leb128() animation_type;
   AnimatedParameterData<signed int (16)> param_data;
@@ -1532,8 +1361,6 @@ class mix_gain_parameter_data() {
 ```
 
 <b>Semantics</b>
-
-<dfn noexport>default_mix_gain</dfn> specifies the default mix gain value to apply when there are no mix gain parameter blocks provided. This value is expressed in dB and shall be applied to all channels in the rendered audio element. It is stored as a 16-bit, signed, two's complement fixed-point value with 8 fractional bits (i.e. Q7.8 in [[!Q-Format]]).
 
 <dfn noexport>animation_type</dfn> specifies the type of animation applied to the parameter values.
 
@@ -1574,6 +1401,182 @@ class AnimatedParameterData(animation_type) {
 <dfn noexport>control_point_value</dfn> specifies the parameter value of the middle control point of a quadratic Bezier curve, i.e. its y-axis value.
 
 <dfn noexport>control_point_relative_time</dfn> specifies the time of the middle control point of a quadratic Bezier curve, i.e. its x-axis value. This value is expressed as a fraction of the parameter segment interval with valid values in the range of 0 and 1, inclusively. A value equal to 0 or 1 indicates that this animation implements a linear Bezier curve, in which case control_point_value shall be ignored by the IA parser. It is stored as an 8-bit, unsigned, fixed-point value with 8 fractional bits (i.e. Q0.8 in [[!Q-Format]]).
+
+### Demixing Info Parameter Data Syntax and Semantics ### {#syntax-demixing-info}
+
+<dfn noexport>demixing_info_parameter_data()</dfn> specifies demixing parameter mode to be used to reconstruct output channel audio according to its [=loudspeaker_layout=].
+
+<b>Syntax</b>
+
+```
+class demixing_info_parameter_data() {
+  unsigned int (3) dmixp_mode;
+  unsigned int (5) reserved;
+}
+```
+
+<b>Semantics</b>
+
+<dfn noexport>dmixp_mode</dfn> indicates a mode of pre-defined combinations of five demix parameters.
+- 0: mode1, (alpha, beta, gamma, delta, w_idx_offset) = (1, 1, 0.707, 0.707, -1)
+- 1: mode2, (alpha, beta, gamma, delta, w_idx_offset) = (0.707, 0.707, 0.707, 0.707, -1)
+- 2: mode3, (alpha, beta, gamma, delta, w_idx_offset) = (1, 0.866, 0.866, 0.866, -1)
+- 3: reserved
+- 4: mode1, (alpha, beta, gamma, delta, w_idx_offset) = (1, 1, 0.707, 0.707, 1)
+- 5: mode2, (alpha, beta, gamma, delta, w_idx_offset) = (0.707, 0.707, 0.707, 0.707, 1)
+- 6: mode3, (alpha, beta, gamma, delta, w_idx_offset) = (1, 0.866, 0.866, 0.866, 1)
+- 7: reserved
+
+<dfn noexport>alpha</dfn> and <dfn noexport>beta</dfn> are gain values used for S7to5 down-mixer, <dfn noexport>gamma</dfn> for T4to2 down-mixer, <dfn noexport>delta</dfn> for S5to3 down-mixer and <dfn noexport>w_idx_offset</dfn> is the offset to generate a gain value <dfn noexport>w</dfn> used for T2toTF2 down-mixer.
+
+<center><img src="images/Down-mix Mechanism.png" style="width:100%; height:auto;"></center>
+<center><figcaption></b>IA Down-mix Mechanism</figcaption></center>
+
+### Recon Gain Info Parameter Data Syntax and Semantics ### {#syntax-recon-gain-info}
+
+<dfn noexport>recon_gain_info_parameter_data()</dfn> contains recon gain values for demixed channels.
+
+NOTE: [=recon_gain_info_parameter_data()=] is required to compensate the propagated errors by De-mixer and Gain modules specified in [[#processing-scalablechannelaudio-demixer]] and [[#processing-scalablechannelaudio-gain]] due to the error caused by lossy codecs such as IAMF-OPUS and IAMF-AAC-LC. However, it is not required for lossless codecs such as IAMF-FLAC and IAMF-LPCM because the propagated errors are negligible.
+
+<b>Syntax</b>
+
+```
+class recon_gain_info_parameter_data() {
+  for (i=0; i< num_layers; i++) {
+    if (recon_gain_is_present_flag(i) == 1) {
+      leb128() recon_gain_flags(i);
+      for (j=0; j< n(i); j++) {
+        if (recon_gain_flag(i)(j) == 1)
+          unsigned int (8) recon_gain;
+      }
+    }
+  }
+}
+```
+
+<b>Semantics</b>
+
+<dfn noexport>recon_gain_flags</dfn> indicates the channels which recon_gain is applied to.
+
+<left><img src="images/Recon_Gain_Flags.png" style="width:100%; height:auto;"></left>
+<center><figcaption>Table for Recon Gain Flags</figcaption></center>
+
+The each bit of [=recon_gain_flags=] indicates the presence of [=recon_gain=] applied to the channel as depicted in the above figure.
+ - 0: It indicates that no [=recon_gain=] presents for the channel.
+ - 1: It indicates that [=recon_gain=] presents for the channel.
+
+<dfn noexport>n(i)</dfn> indicates the number of bits for recon_gain_flag(i). It shall be 7 or 12 as depicted in the above figure. Where, i = 0, 1, ..., [=num_layers=] - 1.
+
+<dfn noexport>recon_gain</dfn> indicates the gain value to be applied to the channel, which is indicated by [=recon_gain_flags=], after decoding of the associated frames and demixing operation. Where, the channel is indicated by recon_gain_flags. Detailed operation by using this value is specified in [[#processing-scalablechannelaudio-recongain]].
+
+
+## Audio Frame OBU Syntax and Semantics ## {#obu-audioframe}
+
+This section specifies OBU payloads of OBU_IA_Audio_Frame and OBU_IA_Audio_Frame_ID0 to OBU_IA_Audio_Frame_ID21. 
+
+The first 22 audio substreams in an IA sequence may use the OBU types OBU_IA_Audio_Frame_ID0 to OBU_IA_Audio_Frame_ID21, which have predefined audio substream obu_ids associated with them. This avoids the need to manually specify an [=audio_substream_id=].
+
+[=audio_substream_id=] = 0 to [=audio_substream_id=] = 21 shall be assigned to Audio Frame OBUs with the OBU types OBU_IA_Audio_Frame_ID0 to OBU_IA_Audio_Frame_ID21, respectively. 
+
+<b>Syntax</b>
+
+```
+class audio_frame_obu_with_no_id() {
+  leb128() audio_substream_id;
+  audio_frame_obu(audio_substream_id);
+}
+```
+
+```
+class audio_frame_obu() {
+  unsigned int (8*coded_frame_size) audio_frame();
+}
+```
+
+<b>Semantics</b>
+
+<dfn noexport>audio_substream_id</dfn> indicates an unique obu_id with [=obu_type=] = OBU_IA_Audio_Frame in IA sequences for a given substream. All Audio Frame OBUs of the same substream shall have the same audio_substream_id.
+
+This value must be greater or equal to 22, in order to avoid collision with the reserved IDs for the OBU types OBU_IA_Audio_Frame_ID0 to OBU_IA_Audio_Frame_ID21.
+
+<dfn noexport>coded_frame_size</dfn> is the size of [=audio_frame()=] in bytes.
+
+<dfn noexport>audio_frame()</dfn> is the raw coded audio data for the frame. It shall be [=opus packet=] of [[!RFC6716]] for IAMF-OPUS, [=raw_data_block()=] of [[!AAC]] for IAMF-AAC-LC and [=FRAME=] of [[!FLAC]] for IAMF-FLAC.
+
+For IAMF-LPCM, [=audio_frame()=] shall be LPCM samples. When more than one byte is used to represent a LPCM sample, the byte order is in little endian. 
+
+For this version of the specification, all audio frames for a given substream must be gapless.
+
+## Temporal Delimiter OBU Syntax and Semantics ## {#obu-temporaldelimiter}
+
+This section specifies the OBU payload of OBU_IA_Temporal_Delimiter.
+
+<b>Syntax</b>
+
+```
+class temporal_delimiter_obu() {
+}
+```
+
+NOTE: The Temporal Delimiter OBU has an empty payload.
+
+## Sync OBU Syntax and Semantics ## {#obu-sync}
+
+This section specifies the OBU payload of OBU_IA_Sync.
+
+<b>Syntax</b>
+
+```
+class sync_obu() {
+  leb128() global_offset;
+  leb128() num_obu_ids;
+  for (i = 0; i < num_obu_ids; i++) {
+    leb128() obu_id;
+    unsigned int (1) obu_data_type;
+    unsigned int (1) reinitialize_decoder;
+    unsigned int (6) reserved;
+    sleb128() relative_offset;
+  }
+}
+```
+
+<b>Semantics</b>
+
+<dfn noexport>global_offset</dfn> specifies the offset that is applied to all substreams and parameters specified in this Sync OBU, in addition to their individual relative offsets.
+
+For this version of the specification, the value of global_offset shall be set to 0.
+
+<dfn noexport>num_obu_ids</dfn> specifies the number of substream and parameter IDs that this Sync OBU specifies the offset for.
+
+<dfn noexport>obu_id</dfn> specifies the unique ID associated with the substream or parameter that is being referred to.
+
+<dfn noexport>obu_data_type</dfn> specifies the type of data that is being referred to.
+
+<pre class = "def">
+obu_data_type : Type of OBU data
+      0       : SUBSTREAM
+      1       : PARAMETER
+</pre>
+
+<dfn noexport>reinitialize_decoder</dfn> is used to specify the behaviour of a decoder when encountering gaps in the audio substream, where the gap is identified as described in [[#standalone-synchronizing-data-obus]]. If obu_data_type does not equal SUBSTREAM, an IAMF-OBU parser shall ignore this field.
+
+If reinitialize_decoder = 0, the decoder shall not be reinitialized before decoding the audio frames after the gap. This may be used in the case where it is preferable for the decoder to fill the gap with silence instead.
+
+If reinitialize_decoder = 1, the decoder shall be reinitialized before decoding the audio frames after the gap. If a pre-skip is specified in the relevant Codec Config OBU, it is applicable after reinitializing the decoder.
+
+For this version of the specification, the value of reinitialize_decoder shall be set to 0. If a value of 1 is seen, the IA sequence shall be rejected as invalid.
+
+<dfn value noexport for="sync_obu()">reserved</dfn> shall be set to 0. Reserved units are for future use and shall be ignored by an IAMF-OBU parser.
+
+<dfn noexport>relative_offset</dfn> is the offset to position the first audio frame (before trimming) or parameter block with the referenced obu_id that comes after this Sync OBU with respect to the timeline generated before this Sync OBU. If this Sync OBU is the first one, it is the offset from 0. Otherwise, it is the offset from the end of the timeline of Substreams generated from the previous Sync OBU.
+
+The difference, [=relative_offset=](P) - [=relative_offset=](A), shall be the offset to position the first audio sample where the first parameter value of the first parameter block that comes after this Sync OBU is applied to.
+- Where, [=relative_offset=](P) is [=relative_offset=] of [=obu_id=] for the parameter and [=relative_offset=](A) is [=relative_offset=] of [=obu_id=] for the substream which the parameter is applied to. 
+
+The offset shall be indicated in the number of ticks at the sample rate specified in the corresponding substream or Codec Config OBU. For IAMF-OPUS, the sample rate is 48000Hz.
+
+IA encoder and decoder operations related to this field are specified in [[#standalone-synchronizing-data-obus]].
+
 
 ## Codec Specific ## {#codec-specific}
 
@@ -1965,15 +1968,15 @@ class IA_Descriptor extends Box('iamd') {
 
 <b>Semantics</b>
 
-<dfn value noexport for="IA_Descriptor">magic_code_obu()</dfn> is the [=magic_code_obu()=] in this set of descriptor OBUs.
+<dfn value noexport for="IA_Descriptor">magic_code_obu()</dfn> is the magic_code_obu() in this set of descriptor OBUs.
 
-<dfn value noexport for="IA_Descriptor">codec_config_obu()</dfn> is the [=codec_config_obu()=] in this set of descriptor OBUs.
+<dfn value noexport for="IA_Descriptor">codec_config_obu()</dfn> is the codec_config_obu() in this set of descriptor OBUs.
 
-<dfn value noexport for="IA_Descriptor">audio_element_obu()</dfn> is the <code>i</code>-th [=audio_element_obu()=] in this set of descriptor OBUs.
+<dfn value noexport for="IA_Descriptor">audio_element_obu()</dfn> is the <code>i</code>-th audio_element_obu() in this set of descriptor OBUs.
 
-<dfn value noexport for="IA_Descriptor">mix_presentation_obu()</dfn> is the <code>j</code>-th [=mix_presentation_obu()=] in this set of descriptor OBUs.
+<dfn value noexport for="IA_Descriptor">mix_presentation_obu()</dfn> is the <code>j</code>-th mix_presentation_obu() in this set of descriptor OBUs.
 
-<dfn value noexport for="IA_Descriptor">sync_obu()</dfn> is the [=sync_obu()=] that immediately follows this set of descriptor OBUs.
+<dfn value noexport for="IA_Descriptor">sync_obu()</dfn> is the sync_obu() that immediately follows this set of descriptor OBUs.
 
 ### IA Sample Format ### {#iasampleformat}
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/pull/355.html" title="Last updated on Apr 6, 2023, 1:05 AM UTC (9d99e44)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/355/fb04c27...9d99e44.html" title="Last updated on Apr 6, 2023, 1:05 AM UTC (9d99e44)">Diff</a>