### PR TITLE
Fix #421, add default value for demixing and recon gain

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -649,6 +649,9 @@ class audio_element_obu() {
 
 ```
 class DemixingParamDefinition() extends ParamDefinition() {
+  default_demixing_info_parameter_data();
+  unsigned int (4) default_w;
+  unsigned int (4) reserved;
 }
 ```
 
@@ -715,6 +718,29 @@ A ChannelGroup is defined in [[#iamfgeneration]]. The order of the substreams in
 <dfn noexport>scalable_channel_layout_config()</dfn> is a class that provides the metadata required for combining the substreams identified here in order to reconstruct a scalable channel layout.
 
 <dfn noexport>ambisonics_config()</dfn> is a class that provides the metadata required for combining the substreams identified here in order to reconstruct an Ambisonics layout.
+
+<dfn noexport>default_demixing_info_parameter_data()</dfn> and <dfn noexport>default_w</dfn> specify the default parameter data for demixing to apply to all audio samples when there are no Parameter Block OBUs (with [=parameter_id=] defined in this DemixingParamDefinition()) provided.
+- [=default_demixing_info_parameter_data()=] conforms to [=demixing_info_parameter_data()=] except that [=w_idx_offset=] shall be ignored.
+- Instead of that, [=default_w=] directly indicates the weight value [=w(k)=] for [=TF2toT2 de-mixer=] specified in [[#processing-scalablechannelaudio-demixer]].
+
+Mapping of default_w to w(k) should be as follows:
+<pre class = "def">
+ default_w :   w(k)
+    0      :    0
+    1      :  0.0179
+    2      :  0.0391
+    3      :  0.0658
+    4      :  0.1038
+    5      :  0.25
+    6      :  0.3962
+    7      :  0.4342
+    8      :  0.4609
+    9      :  0.4821
+    10     :  0.5
+    11     :  reserved
+</pre>
+
+The default parameter data for recon gain is not explicityly provieded in ReconGainParamDefinition() as the default value of recon gain is just 0dB which requires no operation. It may be no Parameter Block OBUs (with [=parameter_id=] defined in this ReconGainParamDefinition()) provided. 
 
 ### Parameter Definition Syntax and Semantics ### {#parameter-definition}
 

--- a/index.bs
+++ b/index.bs
@@ -740,7 +740,7 @@ Mapping of default_w to w(k) should be as follows:
     11     :  reserved
 </pre>
 
-The default parameter data for recon gain is not explicityly provieded in ReconGainParamDefinition() as the default value of recon gain is just 0dB which requires no operation. It may be no Parameter Block OBUs (with [=parameter_id=] defined in this ReconGainParamDefinition()) provided. 
+A default recon gain value of 0db is implied when there are no Parameter Block OBUs (with [=parameter_id=] defined in this ReconGainParamDefinition()) provided. 
 
 ### Parameter Definition Syntax and Semantics ### {#parameter-definition}
 


### PR DESCRIPTION
- Updated Audio Element OBU syntax and semantic section
 - Explicitly mentioned there may be no parameter block obus for demixing or recon gain.
 - Default values are used when no parameter block obu presents.
 - Added syntaxes for default demixing parameter data


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/pull/431.html" title="Last updated on Jun 2, 2023, 2:06 PM UTC (330e1ac)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/431/795601b...330e1ac.html" title="Last updated on Jun 2, 2023, 2:06 PM UTC (330e1ac)">Diff</a>