### PR TITLE
Fix #419 and fix #415, updated parameterdefinition to support fully aligned PBO and AFO

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -720,6 +720,8 @@ A ChannelGroup is defined in [[#iamfgeneration]]. The order of the substreams in
 
 Parameter definition classes inherits from the abstract <dfn noexport>ParamDefinition()</dfn> class.
 
+For a given parameter, its timeline is fully aligned with that of the Audio Element which the given parameter is applied to. Where, the timeline of the Audio Element is on post coding domain (i.e. before trimming data). So, when we assume the same sample rate between the given Parameter and the Audio Element In other words, the start timestamp and the duration of the given Parameter are same as those of the Audio Elememnt, respectively.
+
 <b>Syntax</b>
 
 ```
@@ -748,6 +750,7 @@ abstract class ParamDefinition() {
 
 <dfn noexport>parameter_rate</dfn> specifies the rate used by this parameter, expressed as ticks per second. Time-related fields associated with this parameter, such as durations, shall be expressed in the number of ticks.
 - In DemixingParamDefinition() or ReconGainParamDefinition(), this field shall be set to the sample rate of the Audio Element which this parameter is applied to.
+- The rate shall be such a value that (the rate x [=num_samples_per_frame=]) / (the sample rate of Audio Element) is still integer.
 
 <dfn noexport>param_definition_mode</dfn> indicates if this parameter definition specifies duration, num_subblocks, constant_subblock_duration and subblock_duration fields for the parameter blocks associated to the [=parameter_id=].
 - When this field is set to 0, all of duration, num_subblocks, constant_subblock_duration and subblock_duration fields shall be specified in this parameter definition mapped to the [=parameter_id=]. In that case, none of parameter blocks associated to this parameter definition shall specify duration, num_subblocks, constant_subblock_duration and subblock_duration fields. 
@@ -757,7 +760,10 @@ abstract class ParamDefinition() {
 	- [=num_subblocks=] shall be set to 1.
 	- [=constant_subblock_duration=] shall be same as [=duration=]
 
-<dfn noexport>duration</dfn> specifies the duration for which all of parameter blocks associated to this parameter definition are valid and applicable. 
+<dfn noexport>duration</dfn> specifies the duration for which all of parameter blocks associated to this parameter definition are valid and applicable.
+- This field shall be set to (([=parameter_rate=] of this parameter) x [=num_samples_per_frame=]) / (the sample rate of Audio Element). 
+- So, if the [=parameter_rate=] = the sample rate of Audio Element, then the [=duration=] shall be same as the [=num_samples_per_frame=].
+
 
 <dfn noexport>num_subblocks</dfn> specifies the number of different sets of parameter values specified in all of parameter blocks associated to this parameter definition, where each set describes a different subblock of the timeline, contiguously.
 
@@ -1353,6 +1359,8 @@ class parameter_block_obu() {
 <dfn noexport>get_param_definition()</dfn> is a run-time function to get the parameter definition type, the parameter definition mode, duration, num_subblocks, constant_subblock_duration and subblock_duration mapped to the parameter_id. 
 
 <dfn value noexport for="parameter_block_obu()">duration</dfn> specifies the duration for which this parameter block is valid and applicable. 
+- This field shall be set to (([=parameter_rate=] of this parameter) x [=num_samples_per_frame=]) / (the sample rate of Audio Element). 
+- So, if the [=parameter_rate=] = the sample rate of Audio Element, then the [=duration=] shall be same as the [=num_samples_per_frame=].
 
 <dfn value noexport for="parameter_block_obu()">num_subblocks</dfn> specifies the number of different sets of parameter values specified in this parameter block, where each set describes a different subblock of the timeline, contiguously.
 

--- a/index.bs
+++ b/index.bs
@@ -1588,6 +1588,7 @@ For this version of the specification, the value of reinitialize_decoder shall b
 <dfn value noexport for="sync_obu()">reserved</dfn> shall be set to 0. Reserved units are for future use and shall be ignored by an IAMF-OBU parser.
 
 <dfn noexport>relative_offset</dfn> is the offset to position the first audio frame (before trimming) or parameter block with the referenced obu_id that comes after this Sync OBU with respect to the timeline generated before this Sync OBU. If this Sync OBU is the first one, it is the offset from 0. Otherwise, it is the offset from the end of the timeline of Substreams generated from the previous Sync OBU.
+- For this version of the specification, it shall be set to 0 for all ids.
 
 The difference, [=relative_offset=](P) - [=relative_offset=](A), shall be the offset to position the first audio sample where the first parameter value of the first parameter block that comes after this Sync OBU is applied to.
 - Where, [=relative_offset=](P) is [=relative_offset=] of [=obu_id=] for the parameter and [=relative_offset=](A) is [=relative_offset=] of [=obu_id=] for the substream which the parameter is applied to. 

--- a/index.bs
+++ b/index.bs
@@ -747,10 +747,15 @@ abstract class ParamDefinition() {
 <dfn value noexport for="ParamDefinition()">parameter_id</dfn> indicates the identifier for the Parameter which this parameter definition refers to.
 
 <dfn noexport>parameter_rate</dfn> specifies the rate used by this parameter, expressed as ticks per second. Time-related fields associated with this parameter, such as durations, shall be expressed in the number of ticks.
+- In DemixingParamDefinition() or ReconGainParamDefinition(), this field shall be set to the sample rate of the Audio Element which this parameter is applied to.
 
 <dfn noexport>param_definition_mode</dfn> indicates if this parameter definition specifies duration, num_subblocks, constant_subblock_duration and subblock_duration fields for the parameter blocks associated to the [=parameter_id=].
 - When this field is set to 0, all of duration, num_subblocks, constant_subblock_duration and subblock_duration fields shall be specified in this parameter definition mapped to the [=parameter_id=]. In that case, none of parameter blocks associated to this parameter definition shall specify duration, num_subblocks, constant_subblock_duration and subblock_duration fields. 
 - When this field is set to 1, none of duration, num_subblocks, constant_subblock_duration and subblock_duration fields shall be specificed in this parameter definition. In that case, each of parameter blocks associated to this parameter definition shall specify its own duration, num_subblocks, constant_subblock_duration and subblock_duration fields.
+- This field shall be set to 0 for DemixingParamDefinition() or ReconGainParamDefinition().
+	- [=duration=] shall be same as [=num_samples_per_frame=] of the Audio Element which this parameter is applied to.
+	- [=num_subblocks=] shall be set to 1.
+	- [=constant_subblock_duration=] shall be same as [=duration=]
 
 <dfn noexport>duration</dfn> specifies the duration for which all of parameter blocks associated to this parameter definition are valid and applicable. 
 


### PR DESCRIPTION
Updated ParameterDefinition for Demixing and Recon Gain to have only one single subblock.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/pull/433.html" title="Last updated on May 24, 2023, 12:00 AM UTC (c927643)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/433/795601b...c927643.html" title="Last updated on May 24, 2023, 12:00 AM UTC (c927643)">Diff</a>