### PR TITLE
Issue #384: Clarify Opus output sample rate should be 48 kHz (try 2)

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -73,6 +73,7 @@ url: https://www.iso.org/standard/76383.html#; spec: MP4-Audio; type: dfn;
 	text: frameLengthFlag
 	text: dependsOnCoreCoder
 	text: extensionFlag
+	text: samplingFrequencyIndex
 
 url: https://www.iso.org/standard/79110.html#; spec: MP4; type: dfn;
 	text: ESDBox
@@ -1629,6 +1630,7 @@ For legacy codecs, Decoder_Config() shall be exactly the same information as the
 
 Substream format is [=opus packet=] of [[!RFC6716]] which contains only one single frame of mono or stereo channels and which has non-delimiting frame structure.
 
+The sample rate used for computing offsets shall be 48 kHz.
 
 ### IAMF-AAC-LC Specific ### {#iamf-aac-lc-specific}
 
@@ -1648,6 +1650,8 @@ Substream format is [=opus packet=] of [[!RFC6716]] which contains only one sing
 
 Substream format is one single [=raw_data_block()=] of [[!AAC]] which contains only one single frame of mono or stereo channels.
 
+The sample rate used for computing offsets shall be the rate indicated by the [=samplingFrequencyIndex=] in [=GASpecificConfig()=]
+
 ### IAMF-FLAC Specific ### {#iamf-flac-specific}
 
 [=Codec_ID=] shall be 'fLaC', the FLAC stream marker in ASCII, meaning byte 0 of the stream is 0x66, followed by 0x4C 0x61 0x43.
@@ -1655,6 +1659,8 @@ Substream format is one single [=raw_data_block()=] of [[!AAC]] which contains o
 [=Decoder_Config()=] for IAMF-FLAC is [=METADATA_BLOCK=] of [[!FLAC]].
 
 Substream format is [=FRAME=] of [[!FLAC]], which is composed of [=FRAME_HEADER=], followed by [=SUBFRAME=](s) (one [=SUBFRAME=] per channel) and followed by [=FRAME_FOOTER=].
+
+The sample rate used for computing offsets shall be the sampling rate indicated in the [=METADATA_BLOCK=].
 
 ### IAMF-LPCM Specific ### {#iamf-lpcm-specific}
 
@@ -1677,6 +1683,8 @@ class decoder_config(ipcm) {
 
 Substream format is one [=audio_frame()=] of Audio_Frame_OBU which contains only one single PCM audio frame of mono or stereo channels.
 	- In case of that [=audio_frame()=] contains one single PCM audio frame of stereo channels, the ith audio sample of the left channel is followed by the ith audio sample of the right channel, and then the (i+1)th audio sample of the left channel is followed by the (i+1)th audio sample of the right channel, where i = 1, 2, ..., [=num_samples_per_frame=].
+
+The sample rate used for computing offsets shall be <dfn noexport>sample_rate</dfn>.
 
 # Profiles # {#profiles}
 


### PR DESCRIPTION
This is #385 with my suggestions applied.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jun 12, 2023, 6:38 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2FAOMediaCodec%2Fiamf%2Ff6f929bc9c2efc7314cd04d59b68dfc4f0d3e04e%2Findex.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 2.
Your document appears to use tabs to indent, but line 267 starts with spaces.
Your document appears to use tabs to indent, but line 268 starts with spaces.
Your document appears to use tabs to indent, but line 269 starts with spaces.
Your document appears to use tabs to indent, but line 270 starts with spaces.
Your document appears to use tabs to indent, but line 271 starts with spaces.
Your document appears to use tabs to indent, but line 272 starts with spaces.
Your document appears to use tabs to indent, but line 273 starts with spaces.
Your document appears to use tabs to indent, but line 275 starts with spaces.
Your document appears to use tabs to indent, but line 276 starts with spaces.
Your document appears to use tabs to indent, but line 277 starts with spaces.
Your document appears to use tabs to indent, but line 278 starts with spaces.
Your document appears to use tabs to indent, but line 279 starts with spaces.
Your document appears to use tabs to indent, but line 282 starts with spaces.
Your document appears to use tabs to indent, but line 284 starts with spaces.
Your document appears to use tabs to indent, but line 289 starts with spaces.
Your document appears to use tabs to indent, but line 292 starts with spaces.
Your document appears to use tabs to indent, but line 295 starts with spaces.
Your document appears to use tabs to indent, but line 298 starts with spaces.
Your document appears to use tabs to indent, but line 301 starts with spaces.
Your document appears to use tabs to indent, but line 304 starts with spaces.
Your document appears to use tabs to indent, but line 307 starts with spaces.
Your document appears to use tabs to indent, but line 322 starts with spaces.
Your document appears to use tabs to indent, but line 326 starts with spaces.
Your document appears to use tabs to indent, but line 331 starts with spaces.
Your document appears to use tabs to indent, but line 333 starts with spaces.
Your document appears to use tabs to indent, but line 347 starts with spaces.
Your document appears to use tabs to indent, but line 348 starts with spaces.
Your document appears to use tabs to indent, but line 349 starts with spaces.
Your document appears to use tabs to indent, but line 350 starts with spaces.
Your document appears to use tabs to indent, but line 424 starts with spaces.
Your document appears to use tabs to indent, but line 426 starts with spaces.
Your document appears to use tabs to indent, but line 427 starts with spaces.
Your document appears to use tabs to indent, but line 428 starts with spaces.
Your document appears to use tabs to indent, but line 429 starts with spaces.
Your document appears to use tabs to indent, but line 430 starts with spaces.
Your document appears to use tabs to indent, but line 431 starts with spaces.
Your document appears to use tabs to indent, but line 432 starts with spaces.
Your document appears to use tabs to indent, but line 433 starts with spaces.
Your document appears to use tabs to indent, but line 434 starts with spaces.
Your document appears to use tabs to indent, but line 435 starts with spaces.
Your document appears to use tabs to indent, but line 436 starts with spaces.
Your document appears to use tabs to indent, but line 437 starts with spaces.
Your document appears to use tabs to indent, but line 438 starts with spaces.
Your document appears to use tabs to indent, but line 439 starts with spaces.
Your document appears to use tabs to indent, but line 440 starts with spaces.
Your document appears to use tabs to indent, but line 441 starts with spaces.
Your document appears to use tabs to indent, but line 442 starts with spaces.
Your document appears to use tabs to indent, but line 443 starts with spaces.
Your document appears to use tabs to indent, but line 445 starts with spaces.
Your document appears to use tabs to indent, but line 460 starts with spaces.
Your document appears to use tabs to indent, but line 461 starts with spaces.
Your document appears to use tabs to indent, but line 462 starts with spaces.
Your document appears to use tabs to indent, but line 463 starts with spaces.
Your document appears to use tabs to indent, but line 464 starts with spaces.
Your document appears to use tabs to indent, but line 466 starts with spaces.
Your document appears to use tabs to indent, but line 467 starts with spaces.
Your document appears to use tabs to indent, but line 468 starts with spaces.
Your document appears to use tabs to indent, but line 469 starts with spaces.
Your document appears to use tabs to indent, but line 470 starts with spaces.
Your document appears to use tabs to indent, but line 471 starts with spaces.
Your document appears to use tabs to indent, but line 483 starts with spaces.
Your document appears to use tabs to indent, but line 484 starts with spaces.
Your document appears to use tabs to indent, but line 485 starts with spaces.
Your document appears to use tabs to indent, but line 486 starts with spaces.
Your document appears to use tabs to indent, but line 487 starts with spaces.
Your document appears to use tabs to indent, but line 488 starts with spaces.
Your document appears to use tabs to indent, but line 489 starts with spaces.
Your document appears to use tabs to indent, but line 490 starts with spaces.
Your document appears to use tabs to indent, but line 491 starts with spaces.
Your document appears to use tabs to indent, but line 538 starts with spaces.
Your document appears to use tabs to indent, but line 539 starts with spaces.
Your document appears to use tabs to indent, but line 567 starts with spaces.
Your document appears to use tabs to indent, but line 568 starts with spaces.
Your document appears to use tabs to indent, but line 569 starts with spaces.
Your document appears to use tabs to indent, but line 599 starts with spaces.
Your document appears to use tabs to indent, but line 600 starts with spaces.
Your document appears to use tabs to indent, but line 604 starts with spaces.
Your document appears to use tabs to indent, but line 605 starts with spaces.
Your document appears to use tabs to indent, but line 606 starts with spaces.
Your document appears to use tabs to indent, but line 607 starts with spaces.
Your document appears to use tabs to indent, but line 636 starts with spaces.
Your document appears to use tabs to indent, but line 637 starts with spaces.
Your document appears to use tabs to indent, but line 638 starts with spaces.
Your document appears to use tabs to indent, but line 639 starts with spaces.
Your document appears to use tabs to indent, but line 640 starts with spaces.
Your document appears to use tabs to indent, but line 642 starts with spaces.
Your document appears to use tabs to indent, but line 643 starts with spaces.
Your document appears to use tabs to indent, but line 644 starts with spaces.
Your document appears to use tabs to indent, but line 645 starts with spaces.
Your document appears to use tabs to indent, but line 646 starts with spaces.
Your document appears to use tabs to indent, but line 647 starts with spaces.
Your document appears to use tabs to indent, but line 648 starts with spaces.
Your document appears to use tabs to indent, but line 649 starts with spaces.
Your document appears to use tabs to indent, but line 650 starts with spaces.
Your document appears to use tabs to indent, but line 651 starts with spaces.
Your document appears to use tabs to indent, but line 652 starts with spaces.
Your document appears to use tabs to indent, but line 653 starts with spaces.
Your document appears to use tabs to indent, but line 654 starts with spaces.
Your document appears to use tabs to indent, but line 655 starts with spaces.
Your document appears to use tabs to indent, but line 656 starts with spaces.
Your document appears to use tabs to indent, but line 658 starts with spaces.
Your document appears to use tabs to indent, but line 659 starts with spaces.
Your document appears to use tabs to indent, but line 660 starts with spaces.
Your document appears to use tabs to indent, but line 661 starts with spaces.
Your document appears to use tabs to indent, but line 662 starts with spaces.
Your document appears to use tabs to indent, but line 668 starts with spaces.
Your document appears to use tabs to indent, but line 669 starts with spaces.
Your document appears to use tabs to indent, but line 670 starts with spaces.
Your document appears to use tabs to indent, but line 688 starts with spaces.
Your document appears to use tabs to indent, but line 689 starts with spaces.
Your document appears to use tabs to indent, but line 690 starts with spaces.
Your document appears to use tabs to indent, but line 726 starts with spaces.
Your document appears to use tabs to indent, but line 729 starts with spaces.
Your document appears to use tabs to indent, but line 732 starts with spaces.
Your document appears to use tabs to indent, but line 735 starts with spaces.
Your document appears to use tabs to indent, but line 761 starts with spaces.
Your document appears to use tabs to indent, but line 762 starts with spaces.
Your document appears to use tabs to indent, but line 763 starts with spaces.
Your document appears to use tabs to indent, but line 764 starts with spaces.
Your document appears to use tabs to indent, but line 765 starts with spaces.
Your document appears to use tabs to indent, but line 766 starts with spaces.
Your document appears to use tabs to indent, but line 767 starts with spaces.
Your document appears to use tabs to indent, but line 768 starts with spaces.
Your document appears to use tabs to indent, but line 769 starts with spaces.
Your document appears to use tabs to indent, but line 770 starts with spaces.
Your document appears to use tabs to indent, but line 771 starts with spaces.
Your document appears to use tabs to indent, but line 772 starts with spaces.
Your document appears to use tabs to indent, but line 773 starts with spaces.
Your document appears to use tabs to indent, but line 788 starts with spaces.
Your document appears to use tabs to indent, but line 789 starts with spaces.
Your document appears to use tabs to indent, but line 790 starts with spaces.
Your document appears to use tabs to indent, but line 791 starts with spaces.
Your document appears to use tabs to indent, but line 792 starts with spaces.
Your document appears to use tabs to indent, but line 793 starts with spaces.
Your document appears to use tabs to indent, but line 794 starts with spaces.
Your document appears to use tabs to indent, but line 795 starts with spaces.
Your document appears to use tabs to indent, but line 796 starts with spaces.
Your document appears to use tabs to indent, but line 797 starts with spaces.
Your document appears to use tabs to indent, but line 798 starts with spaces.
Your document appears to use tabs to indent, but line 799 starts with spaces.
Your document appears to use tabs to indent, but line 800 starts with spaces.
Your document appears to use tabs to indent, but line 801 starts with spaces.
Your document appears to use tabs to indent, but line 802 starts with spaces.
Your document appears to use tabs to indent, but line 840 starts with spaces.
Your document appears to use tabs to indent, but line 841 starts with spaces.
Your document appears to use tabs to indent, but line 842 starts with spaces.
Your document appears to use tabs to indent, but line 843 starts with spaces.
Your document appears to use tabs to indent, but line 844 starts with spaces.
Your document appears to use tabs to indent, but line 848 starts with spaces.
Your document appears to use tabs to indent, but line 849 starts with spaces.
Your document appears to use tabs to indent, but line 850 starts with spaces.
Your document appears to use tabs to indent, but line 851 starts with spaces.
Your document appears to use tabs to indent, but line 852 starts with spaces.
Your document appears to use tabs to indent, but line 853 starts with spaces.
Your document appears to use tabs to indent, but line 854 starts with spaces.
Your document appears to use tabs to indent, but line 855 starts with spaces.
Your document appears to use tabs to indent, but line 856 starts with spaces.
Your document appears to use tabs to indent, but line 857 starts with spaces.
Your document appears to use tabs to indent, but line 858 starts with spaces.
Your document appears to use tabs to indent, but line 898 starts with spaces.
Your document appears to use tabs to indent, but line 899 starts with spaces.
Your document appears to use tabs to indent, but line 900 starts with spaces.
Your document appears to use tabs to indent, but line 901 starts with spaces.
Your document appears to use tabs to indent, but line 902 starts with spaces.
Your document appears to use tabs to indent, but line 903 starts with spaces.
Your document appears to use tabs to indent, but line 904 starts with spaces.
Your document appears to use tabs to indent, but line 905 starts with spaces.
Your document appears to use tabs to indent, but line 906 starts with spaces.
Your document appears to use tabs to indent, but line 907 starts with spaces.
Your document appears to use tabs to indent, but line 908 starts with spaces.
Your document appears to use tabs to indent, but line 948 starts with spaces.
Your document appears to use tabs to indent, but line 949 starts with spaces.
Your document appears to use tabs to indent, but line 950 starts with spaces.
Your document appears to use tabs to indent, but line 951 starts with spaces.
Your document appears to use tabs to indent, but line 952 starts with spaces.
Your document appears to use tabs to indent, but line 953 starts with spaces.
Your document appears to use tabs to indent, but line 968 starts with spaces.
Your document appears to use tabs to indent, but line 969 starts with spaces.
Your document appears to use tabs to indent, but line 970 starts with spaces.
Your document appears to use tabs to indent, but line 971 starts with spaces.
Your document appears to use tabs to indent, but line 972 starts with spaces.
Your document appears to use tabs to indent, but line 973 starts with spaces.
Your document appears to use tabs to indent, but line 977 starts with spaces.
Your document appears to use tabs to indent, but line 978 starts with spaces.
Your document appears to use tabs to indent, but line 979 starts with spaces.
Your document appears to use tabs to indent, but line 983 starts with spaces.
Your document appears to use tabs to indent, but line 984 starts with spaces.
Your document appears to use tabs to indent, but line 985 starts with spaces.
Your document appears to use tabs to indent, but line 986 starts with spaces.
Your document appears to use tabs to indent, but line 996 starts with spaces.
Your document appears to use tabs to indent, but line 997 starts with spaces.
Your document appears to use tabs to indent, but line 1032 starts with spaces.
Your document appears to use tabs to indent, but line 1033 starts with spaces.
Your document appears to use tabs to indent, but line 1034 starts with spaces.
Your document appears to use tabs to indent, but line 1035 starts with spaces.
Your document appears to use tabs to indent, but line 1036 starts with spaces.
Your document appears to use tabs to indent, but line 1037 starts with spaces.
Your document appears to use tabs to indent, but line 1038 starts with spaces.
Your document appears to use tabs to indent, but line 1039 starts with spaces.
Your document appears to use tabs to indent, but line 1041 starts with spaces.
Your document appears to use tabs to indent, but line 1042 starts with spaces.
Your document appears to use tabs to indent, but line 1043 starts with spaces.
Your document appears to use tabs to indent, but line 1044 starts with spaces.
Your document appears to use tabs to indent, but line 1045 starts with spaces.
Your document appears to use tabs to indent, but line 1046 starts with spaces.
Your document appears to use tabs to indent, but line 1047 starts with spaces.
Your document appears to use tabs to indent, but line 1048 starts with spaces.
Your document appears to use tabs to indent, but line 1049 starts with spaces.
Your document appears to use tabs to indent, but line 1050 starts with spaces.
Your document appears to use tabs to indent, but line 1051 starts with spaces.
Your document appears to use tabs to indent, but line 1052 starts with spaces.
Your document appears to use tabs to indent, but line 1053 starts with spaces.
Your document appears to use tabs to indent, but line 1054 starts with spaces.
Your document appears to use tabs to indent, but line 1055 starts with spaces.
Your document appears to use tabs to indent, but line 1056 starts with spaces.
Your document appears to use tabs to indent, but line 1057 starts with spaces.
Your document appears to use tabs to indent, but line 1058 starts with spaces.
Your document appears to use tabs to indent, but line 1059 starts with spaces.
Your document appears to use tabs to indent, but line 1102 starts with spaces.
Your document appears to use tabs to indent, but line 1111 starts with spaces.
Your document appears to use tabs to indent, but line 1125 starts with spaces.
Your document appears to use tabs to indent, but line 1154 starts with spaces.
Your document appears to use tabs to indent, but line 1160 starts with spaces.
Your document appears to use tabs to indent, but line 1179 starts with spaces.
Your document appears to use tabs to indent, but line 1196 starts with spaces.
Your document appears to use tabs to indent, but line 1197 starts with spaces.
Your document appears to use tabs to indent, but line 1198 starts with spaces.
Your document appears to use tabs to indent, but line 1199 starts with spaces.
Your document appears to use tabs to indent, but line 1200 starts with spaces.
Your document appears to use tabs to indent, but line 1201 starts with spaces.
Your document appears to use tabs to indent, but line 1202 starts with spaces.
Your document appears to use tabs to indent, but line 1203 starts with spaces.
Your document appears to use tabs to indent, but line 1204 starts with spaces.
Your document appears to use tabs to indent, but line 1205 starts with spaces.
Your document appears to use tabs to indent, but line 1206 starts with spaces.
Your document appears to use tabs to indent, but line 1207 starts with spaces.
Your document appears to use tabs to indent, but line 1208 starts with spaces.
Your document appears to use tabs to indent, but line 1209 starts with spaces.
Your document appears to use tabs to indent, but line 1210 starts with spaces.
Your document appears to use tabs to indent, but line 1220 starts with spaces.
Your document appears to use tabs to indent, but line 1221 starts with spaces.
Your document appears to use tabs to indent, but line 1222 starts with spaces.
Your document appears to use tabs to indent, but line 1223 starts with spaces.
Your document appears to use tabs to indent, but line 1238 starts with spaces.
Your document appears to use tabs to indent, but line 1244 starts with spaces.
Your document appears to use tabs to indent, but line 1247 starts with spaces.
Your document appears to use tabs to indent, but line 1250 starts with spaces.
Your document appears to use tabs to indent, but line 1253 starts with spaces.
Your document appears to use tabs to indent, but line 1256 starts with spaces.
Your document appears to use tabs to indent, but line 1259 starts with spaces.
Your document appears to use tabs to indent, but line 1262 starts with spaces.
Your document appears to use tabs to indent, but line 1265 starts with spaces.
Your document appears to use tabs to indent, but line 1268 starts with spaces.
Your document appears to use tabs to indent, but line 1271 starts with spaces.
Your document appears to use tabs to indent, but line 1274 starts with spaces.
Your document appears to use tabs to indent, but line 1277 starts with spaces.
Your document appears to use tabs to indent, but line 1280 starts with spaces.
Your document appears to use tabs to indent, but line 1283 starts with spaces.
Your document appears to use tabs to indent, but line 1286 starts with spaces.
Your document appears to use tabs to indent, but line 1289 starts with spaces.
Your document appears to use tabs to indent, but line 1292 starts with spaces.
Your document appears to use tabs to indent, but line 1295 starts with spaces.
Your document appears to use tabs to indent, but line 1298 starts with spaces.
Your document appears to use tabs to indent, but line 1301 starts with spaces.
Your document appears to use tabs to indent, but line 1307 starts with spaces.
Your document appears to use tabs to indent, but line 1308 starts with spaces.
Your document appears to use tabs to indent, but line 1309 starts with spaces.
Your document appears to use tabs to indent, but line 1310 starts with spaces.
Your document appears to use tabs to indent, but line 1311 starts with spaces.
Your document appears to use tabs to indent, but line 1312 starts with spaces.
Your document appears to use tabs to indent, but line 1313 starts with spaces.
Your document appears to use tabs to indent, but line 1314 starts with spaces.
Your document appears to use tabs to indent, but line 1315 starts with spaces.
Your document appears to use tabs to indent, but line 1316 starts with spaces.
Your document appears to use tabs to indent, but line 1317 starts with spaces.
Your document appears to use tabs to indent, but line 1318 starts with spaces.
Your document appears to use tabs to indent, but line 1319 starts with spaces.
Your document appears to use tabs to indent, but line 1320 starts with spaces.
Your document appears to use tabs to indent, but line 1332 starts with spaces.
Your document appears to use tabs to indent, but line 1333 starts with spaces.
Your document appears to use tabs to indent, but line 1334 starts with spaces.
Your document appears to use tabs to indent, but line 1336 starts with spaces.
Your document appears to use tabs to indent, but line 1337 starts with spaces.
Your document appears to use tabs to indent, but line 1338 starts with spaces.
Your document appears to use tabs to indent, but line 1340 starts with spaces.
Your document appears to use tabs to indent, but line 1341 starts with spaces.
Your document appears to use tabs to indent, but line 1342 starts with spaces.
Your document appears to use tabs to indent, but line 1343 starts with spaces.
Your document appears to use tabs to indent, but line 1344 starts with spaces.
Your document appears to use tabs to indent, but line 1345 starts with spaces.
Your document appears to use tabs to indent, but line 1346 starts with spaces.
Your document appears to use tabs to indent, but line 1355 starts with spaces.
Your document appears to use tabs to indent, but line 1356 starts with spaces.
Your document appears to use tabs to indent, but line 1357 starts with spaces.
Your document appears to use tabs to indent, but line 1358 starts with spaces.
Your document appears to use tabs to indent, but line 1370 starts with spaces.
Your document appears to use tabs to indent, but line 1371 starts with spaces.
Your document appears to use tabs to indent, but line 1372 starts with spaces.
Your document appears to use tabs to indent, but line 1373 starts with spaces.
Your document appears to use tabs to indent, but line 1394 starts with spaces.
Your document appears to use tabs to indent, but line 1395 starts with spaces.
Your document appears to use tabs to indent, but line 1396 starts with spaces.
Your document appears to use tabs to indent, but line 1397 starts with spaces.
Your document appears to use tabs to indent, but line 1398 starts with spaces.
Your document appears to use tabs to indent, but line 1399 starts with spaces.
Your document appears to use tabs to indent, but line 1400 starts with spaces.
Your document appears to use tabs to indent, but line 1401 starts with spaces.
Your document appears to use tabs to indent, but line 1402 starts with spaces.
Your document appears to use tabs to indent, but line 1404 starts with spaces.
Your document appears to use tabs to indent, but line 1405 starts with spaces.
Your document appears to use tabs to indent, but line 1406 starts with spaces.
Your document appears to use tabs to indent, but line 1407 starts with spaces.
Your document appears to use tabs to indent, but line 1408 starts with spaces.
Your document appears to use tabs to indent, but line 1409 starts with spaces.
Your document appears to use tabs to indent, but line 1411 starts with spaces.
Your document appears to use tabs to indent, but line 1412 starts with spaces.
Your document appears to use tabs to indent, but line 1413 starts with spaces.
Your document appears to use tabs to indent, but line 1414 starts with spaces.
Your document appears to use tabs to indent, but line 1415 starts with spaces.
Your document appears to use tabs to indent, but line 1416 starts with spaces.
Your document appears to use tabs to indent, but line 1417 starts with spaces.
Your document appears to use tabs to indent, but line 1418 starts with spaces.
Your document appears to use tabs to indent, but line 1419 starts with spaces.
Your document appears to use tabs to indent, but line 1420 starts with spaces.
Your document appears to use tabs to indent, but line 1448 starts with spaces.
Your document appears to use tabs to indent, but line 1449 starts with spaces.
Your document appears to use tabs to indent, but line 1461 starts with spaces.
Your document appears to use tabs to indent, but line 1462 starts with spaces.
Your document appears to use tabs to indent, but line 1463 starts with spaces.
Your document appears to use tabs to indent, but line 1471 starts with spaces.
Your document appears to use tabs to indent, but line 1472 starts with spaces.
Your document appears to use tabs to indent, but line 1473 starts with spaces.
Your document appears to use tabs to indent, but line 1474 starts with spaces.
Your document appears to use tabs to indent, but line 1475 starts with spaces.
Your document appears to use tabs to indent, but line 1476 starts with spaces.
Your document appears to use tabs to indent, but line 1477 starts with spaces.
Your document appears to use tabs to indent, but line 1478 starts with spaces.
Your document appears to use tabs to indent, but line 1479 starts with spaces.
Your document appears to use tabs to indent, but line 1480 starts with spaces.
Your document appears to use tabs to indent, but line 1481 starts with spaces.
Your document appears to use tabs to indent, but line 1482 starts with spaces.
Your document appears to use tabs to indent, but line 1483 starts with spaces.
Your document appears to use tabs to indent, but line 1503 starts with spaces.
Your document appears to use tabs to indent, but line 1504 starts with spaces.
Your document appears to use tabs to indent, but line 1535 starts with spaces.
Your document appears to use tabs to indent, but line 1536 starts with spaces.
Your document appears to use tabs to indent, but line 1537 starts with spaces.
Your document appears to use tabs to indent, but line 1538 starts with spaces.
Your document appears to use tabs to indent, but line 1539 starts with spaces.
Your document appears to use tabs to indent, but line 1540 starts with spaces.
Your document appears to use tabs to indent, but line 1541 starts with spaces.
Your document appears to use tabs to indent, but line 1542 starts with spaces.
Your document appears to use tabs to indent, but line 1543 starts with spaces.
Your document appears to use tabs to indent, but line 1555 starts with spaces.
Your document appears to use tabs to indent, but line 1556 starts with spaces.
Your document appears to use tabs to indent, but line 1575 starts with spaces.
Your document appears to use tabs to indent, but line 1576 starts with spaces.
Your document appears to use tabs to indent, but line 1582 starts with spaces.
Your document appears to use tabs to indent, but line 1673 starts with spaces.
Your document appears to use tabs to indent, but line 1674 starts with spaces.
Your document appears to use tabs to indent, but line 1675 starts with spaces.
Your document appears to use tabs to indent, but line 1859 starts with spaces.
Your document appears to use tabs to indent, but line 2060 starts with spaces.
Your document appears to use tabs to indent, but line 2061 starts with spaces.
Your document appears to use tabs to indent, but line 2062 starts with spaces.
Your document appears to use tabs to indent, but line 2063 starts with spaces.
Your document appears to use tabs to indent, but line 2064 starts with spaces.
Your document appears to use tabs to indent, but line 2065 starts with spaces.
Your document appears to use tabs to indent, but line 2066 starts with spaces.
Your document appears to use tabs to indent, but line 2067 starts with spaces.
Your document appears to use tabs to indent, but line 2068 starts with spaces.
Your document appears to use tabs to indent, but line 2069 starts with spaces.
Your document appears to use tabs to indent, but line 2070 starts with spaces.
Your document appears to use tabs to indent, but line 2071 starts with spaces.
Your document appears to use tabs to indent, but line 2145 starts with spaces.
Your document appears to use tabs to indent, but line 2148 starts with spaces.
Your document appears to use tabs to indent, but line 2151 starts with spaces.
Your document appears to use tabs to indent, but line 2154 starts with spaces.
Your document appears to use tabs to indent, but line 2157 starts with spaces.
Your document appears to use tabs to indent, but line 2630 starts with spaces.
WARNING: The heading 'Annex A: ID Linking Scheme (Informative)' needs a manually-specified ID.
WARNING: The heading 'Annex B: Short-lived Audio (Normative)' needs a manually-specified ID.
WARNING: The heading 'Annex' needs a manually-specified ID.
WARNING: At least one &lt;img> doesn't have its size set (&lt;img src="images/decoding_flow_cropped.png" style="width:100%; height:auto;">), but given the type of input document, Bikeshed can't figure out what the size should be.
Either set 'width'/'height' manually, or opt out of auto-detection by setting the 'no-autosize' attribute.
WARNING: Multiple elements have the same ID 'sample_rate'.
Deduping, but this ID may not be stable across revisions.
FATAL ERROR: Multiple local 'dfn' &lt;dfn>s have the same linking text 'sample_rate'.
 ✘  Did not generate, due to fatal errors
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20AOMediaCodec/iamf%23439.)._
</details>
