### PR TITLE
Fix #490, behaviour on num_sub_mixes

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1672,7 +1672,9 @@ Common restrictions on the [=IA Sequence=] for all profiles specified in this ve
 	- [=Parameter Block OBU=]s shall come first and followed by [=Audio Frame OBU=]s. 	  
 - [=num_sub_mixes=] SHOULD be set to 1. Mix Presentation OBUs with [=num_sub_mixes=] > 1 SHOULD be ignored.
 - [=num_audio_elements=] SHOULD be set to 1 or 2. Mix Presentation OBUs with [=num_audio_elements=] > 2 SHOULD be ignored.
-  NOTE: This behavior is to allow future versions of this specification to define new profiles that support a number of audio elements and/or a number of sub-mixes greater than those recommended in this profile, while still permitting streams compliant to these new profiles to be processed by parsers compliant to the profiles defined in this version of the specification.
+
+NOTE: This behavior is to allow future versions of this specification to define new profiles that support a number of audio elements and/or a number of sub-mixes greater than those recommended in this profile, while still permitting streams compliant to these new profiles to be processed by parsers compliant to the profiles defined in this version of the specification.
+
 - When [=num_layers=] = 1, DemixingParameDefinion() for demixng MAY be present in the [=Audio Element OBU=] and IA decoders MAY use the (default) parameter data for demixing for (dynamic) down-mixing.
 - All parameter definitons except DemixingParamDefinition() and ReconGainParamDefinition() SHALL have the same [=param_definition_mode=].
 	- When [=param_definition_mode=] = 0, [=duration=], [=num_subblocks=], [=constant_subblock_duration=] and [=subblock_duration=] SHALL be same in all parameter definitions, respectively.

--- a/index.bs
+++ b/index.bs
@@ -1672,7 +1672,7 @@ Common restrictions on the [=IA Sequence=] for all profiles specified in this ve
 	- [=Parameter Block OBU=]s shall come first and followed by [=Audio Frame OBU=]s. 	  
 - [=num_sub_mixes=] SHOULD be set to 1. Mix Presentation OBUs with [=num_sub_mixes=] > 1 SHOULD be ignored.
 - [=num_audio_elements=] SHOULD be set to 1 or 2. Mix Presentation OBUs with [=num_audio_elements=] > 2 SHOULD be ignored.
-NOTE: This behavior is to allow future versions of this specification to define new profiles that support a number of audio elements and/or a number of sub-mixes greater than those recommended in this profile, while still permitting streams compliant to these new profiles to be processed by parsers compliant to the profiles defined in this version of the specification.
+  NOTE: This behavior is to allow future versions of this specification to define new profiles that support a number of audio elements and/or a number of sub-mixes greater than those recommended in this profile, while still permitting streams compliant to these new profiles to be processed by parsers compliant to the profiles defined in this version of the specification.
 - When [=num_layers=] = 1, DemixingParameDefinion() for demixng MAY be present in the [=Audio Element OBU=] and IA decoders MAY use the (default) parameter data for demixing for (dynamic) down-mixing.
 - All parameter definitons except DemixingParamDefinition() and ReconGainParamDefinition() SHALL have the same [=param_definition_mode=].
 	- When [=param_definition_mode=] = 0, [=duration=], [=num_subblocks=], [=constant_subblock_duration=] and [=subblock_duration=] SHALL be same in all parameter definitions, respectively.

--- a/index.bs
+++ b/index.bs
@@ -1043,7 +1043,7 @@ class mix_presentation_obu() {
 
 <dfn noexport>num_sub_mixes</dfn> specifies the number of sub-mixes. It SHALL NOT be set to 0. For this version of the specification, it SHALL be set to 1. Mix Presentation OBUs with [=num_sub_mixes=] > 1 SHALL be ignored by parsers compliant to this version of the specification.
 
-<dfn noexport>num_audio_elements</dfn> specifies the number of [=Audio Element=]s that are used in this [=Mix Presentation=] to generate the final output audio signal for playback. It SHALL NOT be set to 0. For this version of the specification, it SHALL be set to 1 or 2. Mix Presentation OBUs with [=num_audio_elements=] > 1 SHALL be ignored by parsers compliant to this version of the specification.
+<dfn noexport>num_audio_elements</dfn> specifies the number of [=Audio Element=]s that are used in this [=Mix Presentation=] to generate the final output audio signal for playback. It SHALL NOT be set to 0. For this version of the specification, it SHALL be set to 1 or 2. Mix Presentation OBUs with [=num_audio_elements=] > 2 SHALL be ignored by parsers compliant to this version of the specification.
 
 <dfn value noexport for ="mix_presentation_obu()">audio_element_id</dfn> indicates the identifier for an [=Audio Element=] which this [=Mix Presentation=] refers to.
 

--- a/index.bs
+++ b/index.bs
@@ -1670,8 +1670,9 @@ Common restrictions on the [=IA Sequence=] for all profiles specified in this ve
 - In every [=Temporal Unit=], the start timestamp of every [=Audio Frame OBU=] SHALL be the same as that of every [=Parameter Block OBU=] if present.
 	- There SHALL be no redundant [=Parameter Block OBU=].
 	- [=Parameter Block OBU=]s shall come first and followed by [=Audio Frame OBU=]s. 	  
-- [=num_sub_mixes=] SHALL be set to 1. Mix Presentation OBUs with [=num_sub_mixes=] > 1 SHALL be ignored by parsers compliant to this version of the specification.
-- [=num_audio_elements=] SHALL be set to 1 or 2. Mix Presentation OBUs with [=num_audio_elements=] > 2 SHALL be ignored by parsers compliant to this version of the specification.
+- [=num_sub_mixes=] SHOULD be set to 1. Mix Presentation OBUs with [=num_sub_mixes=] > 1 SHOULD be ignored.
+- [=num_audio_elements=] SHOULD be set to 1 or 2. Mix Presentation OBUs with [=num_audio_elements=] > 2 SHOULD be ignored.
+NOTE: This behavior is to allow future versions of this specification to define new profiles that support a number of audio elements and/or a number of sub-mixes greater than those recommended in this profile, while still permitting streams compliant to these new profiles to be processed by parsers compliant to the profiles defined in this version of the specification.
 - When [=num_layers=] = 1, DemixingParameDefinion() for demixng MAY be present in the [=Audio Element OBU=] and IA decoders MAY use the (default) parameter data for demixing for (dynamic) down-mixing.
 - All parameter definitons except DemixingParamDefinition() and ReconGainParamDefinition() SHALL have the same [=param_definition_mode=].
 	- When [=param_definition_mode=] = 0, [=duration=], [=num_subblocks=], [=constant_subblock_duration=] and [=subblock_duration=] SHALL be same in all parameter definitions, respectively.

--- a/index.bs
+++ b/index.bs
@@ -1041,9 +1041,9 @@ class mix_presentation_obu() {
 
 <dfn noexport>mix_presentation_annotations()</dfn> is a class that provides informational metadata that an IA parser SHOULD refer to when selecting the [=Mix Presentation=] to use. The metadata MAY also be used by the playback system to display information to the user, but is not used in the rendering or mixing process to generate the final output audio signal.
 
-<dfn noexport>num_sub_mixes</dfn> specifies the number of sub-mixes. It SHALL NOT be set to 0. For this version of the specification, it SHALL be set to 1. Mix Presentation OBUs with [=num_sub_mixes=] > 1 SHALL be ignored by parsers compliant to this version of the specification.
+<dfn noexport>num_sub_mixes</dfn> specifies the number of sub-mixes. It SHALL NOT be set to 0. 
 
-<dfn noexport>num_audio_elements</dfn> specifies the number of [=Audio Element=]s that are used in this [=Mix Presentation=] to generate the final output audio signal for playback. It SHALL NOT be set to 0. For this version of the specification, it SHALL be set to 1 or 2. Mix Presentation OBUs with [=num_audio_elements=] > 2 SHALL be ignored by parsers compliant to this version of the specification.
+<dfn noexport>num_audio_elements</dfn> specifies the number of [=Audio Element=]s that are used in this [=Mix Presentation=] to generate the final output audio signal for playback. It SHALL NOT be set to 0. 
 
 <dfn value noexport for ="mix_presentation_obu()">audio_element_id</dfn> indicates the identifier for an [=Audio Element=] which this [=Mix Presentation=] refers to.
 
@@ -1670,7 +1670,8 @@ Common restrictions on the [=IA Sequence=] for all profiles specified in this ve
 - In every [=Temporal Unit=], the start timestamp of every [=Audio Frame OBU=] SHALL be the same as that of every [=Parameter Block OBU=] if present.
 	- There SHALL be no redundant [=Parameter Block OBU=].
 	- [=Parameter Block OBU=]s shall come first and followed by [=Audio Frame OBU=]s. 	  
-- [=num_sub_mixes=] SHALL be set to 1.
+- [=num_sub_mixes=] SHALL be set to 1. Mix Presentation OBUs with [=num_sub_mixes=] > 1 SHALL be ignored by parsers compliant to this version of the specification.
+- [=num_audio_elements=] SHALL be set to 1 or 2. Mix Presentation OBUs with [=num_audio_elements=] > 2 SHALL be ignored by parsers compliant to this version of the specification.
 - When [=num_layers=] = 1, DemixingParameDefinion() for demixng MAY be present in the [=Audio Element OBU=] and IA decoders MAY use the (default) parameter data for demixing for (dynamic) down-mixing.
 - All parameter definitons except DemixingParamDefinition() and ReconGainParamDefinition() SHALL have the same [=param_definition_mode=].
 	- When [=param_definition_mode=] = 0, [=duration=], [=num_subblocks=], [=constant_subblock_duration=] and [=subblock_duration=] SHALL be same in all parameter definitions, respectively.

--- a/index.bs
+++ b/index.bs
@@ -1041,7 +1041,7 @@ class mix_presentation_obu() {
 
 <dfn noexport>mix_presentation_annotations()</dfn> is a class that provides informational metadata that an IA parser SHOULD refer to when selecting the [=Mix Presentation=] to use. The metadata MAY also be used by the playback system to display information to the user, but is not used in the rendering or mixing process to generate the final output audio signal.
 
-<dfn noexport>num_sub_mixes</dfn> specifies the number of sub-mixes.
+<dfn noexport>num_sub_mixes</dfn> specifies the number of sub-mixes. For this version of the specification, [=num_sub_mixes=] SHALL be set to 1. If a decoder or an OBU parser encounters a Mix Presentation OBU with [=num_sub_mixes=] > 1, it SHALL discard the Mix Presentation OBU.
 
 <dfn noexport>num_audio_elements</dfn> specifies the number of [=Audio Element=]s that are used in this [=Mix Presentation=] to generate the final output audio signal for playback.
 

--- a/index.bs
+++ b/index.bs
@@ -1041,9 +1041,9 @@ class mix_presentation_obu() {
 
 <dfn noexport>mix_presentation_annotations()</dfn> is a class that provides informational metadata that an IA parser SHOULD refer to when selecting the [=Mix Presentation=] to use. The metadata MAY also be used by the playback system to display information to the user, but is not used in the rendering or mixing process to generate the final output audio signal.
 
-<dfn noexport>num_sub_mixes</dfn> specifies the number of sub-mixes. For this version of the specification, [=num_sub_mixes=] SHALL be set to 1.  Mix Presentation OBUs with [=num_sub_mixes=] > 1 SHALL be ignored by parsers compliant to this version of the specification.
+<dfn noexport>num_sub_mixes</dfn> specifies the number of sub-mixes. It SHALL NOT be set to 0. For this version of the specification, it SHALL be set to 1. Mix Presentation OBUs with [=num_sub_mixes=] > 1 SHALL be ignored by parsers compliant to this version of the specification.
 
-<dfn noexport>num_audio_elements</dfn> specifies the number of [=Audio Element=]s that are used in this [=Mix Presentation=] to generate the final output audio signal for playback.
+<dfn noexport>num_audio_elements</dfn> specifies the number of [=Audio Element=]s that are used in this [=Mix Presentation=] to generate the final output audio signal for playback. It SHALL NOT be set to 0. For this version of the specification, it SHALL be set to 1 or 2. Mix Presentation OBUs with [=num_audio_elements=] > 1 SHALL be ignored by parsers compliant to this version of the specification.
 
 <dfn value noexport for ="mix_presentation_obu()">audio_element_id</dfn> indicates the identifier for an [=Audio Element=] which this [=Mix Presentation=] refers to.
 

--- a/index.bs
+++ b/index.bs
@@ -1041,7 +1041,7 @@ class mix_presentation_obu() {
 
 <dfn noexport>mix_presentation_annotations()</dfn> is a class that provides informational metadata that an IA parser SHOULD refer to when selecting the [=Mix Presentation=] to use. The metadata MAY also be used by the playback system to display information to the user, but is not used in the rendering or mixing process to generate the final output audio signal.
 
-<dfn noexport>num_sub_mixes</dfn> specifies the number of sub-mixes. For this version of the specification, [=num_sub_mixes=] SHALL be set to 1. If a decoder or an OBU parser encounters a Mix Presentation OBU with [=num_sub_mixes=] > 1, it SHALL discard the Mix Presentation OBU.
+<dfn noexport>num_sub_mixes</dfn> specifies the number of sub-mixes. For this version of the specification, [=num_sub_mixes=] SHALL be set to 1.  Mix Presentation OBUs with [=num_sub_mixes=] > 1 SHALL be ignored by parsers compliant to this version of the specification.
 
 <dfn noexport>num_audio_elements</dfn> specifies the number of [=Audio Element=]s that are used in this [=Mix Presentation=] to generate the final output audio signal for playback.
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/pull/502.html" title="Last updated on Jun 28, 2023, 12:04 AM UTC (c7832ef)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/502/3318721...c7832ef.html" title="Last updated on Jun 28, 2023, 12:04 AM UTC (c7832ef)">Diff</a>