### PR TITLE
Fix #525, to fix convention for string

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2539,9 +2539,9 @@ All of syntax elements conform to [=Syntactic Description Language=] specified i
  
  <b>string</b> <b>syntaxName</b>
 
-<b>string</b> indicates a null-terminated (i.e. ending at the first byte set to 0x00), UTF-8 encoded as defined in [[!RFC3629]] and whose length shall be limited to 128 bytes. 
+<b>string</b> indicates a null-terminated (i.e. ending at the first byte set to 0x00), UTF-8 encoded as defined in [[!RFC3629]] and whose length SHALL be limited to 128 bytes and SHALL not contain the UTF-8 NULL character (0x00) except for the null termination. 
  
-<b>syntaxName</b> is a human readable label. The label shall not include the number 0.
+<b>syntaxName</b> is a human readable label.
  
 ## Arithmetic Operators ## {#convention-arithmetic-operators}
 

--- a/index.bs
+++ b/index.bs
@@ -2539,7 +2539,7 @@ All of syntax elements conform to [=Syntactic Description Language=] specified i
  
  <b>string</b> <b>syntaxName</b>
 
-<b>string</b> indicates a null-terminated (i.e. ending at the first byte set to 0x00), UTF-8 encoded as defined in [[!RFC3629]] and whose length SHALL be limited to 128 bytes and SHALL not contain the UTF-8 NULL character (0x00) except for the null termination. 
+<b>string</b> indicates a null-terminated (i.e. ending at the first byte set to 0x00), UTF-8 encoded as defined in [[!RFC3629]] and whose length SHALL be limited to 128 bytes. 
  
 <b>syntaxName</b> is a human readable label.
  


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/pull/526.html" title="Last updated on Jun 27, 2023, 4:50 PM UTC (2ae4f80)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/526/3318721...2ae4f80.html" title="Last updated on Jun 27, 2023, 4:50 PM UTC (2ae4f80)">Diff</a>