### PR TITLE
Fix #518, Clarify use of AudioSampleEntry channelcount and samplereate

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1827,7 +1827,7 @@ class IASampleEntry extends AudioSampleEntry('iamf') {
 }
 ```
 
-The [=channelcount=] and [=samplerate=] fields of [=AudioSampleEntry=] are unused.
+The [=channelcount=] and [=samplerate=] fields of [=AudioSampleEntry=] are set to 1 and to indicate 48000, respectively. Parsers SHALL ignore these two fields.
 
 None of [=AudioSampleEntry=]'s optional boxes SHALL be present.
 

--- a/index.bs
+++ b/index.bs
@@ -1827,7 +1827,9 @@ class IASampleEntry extends AudioSampleEntry('iamf') {
 }
 ```
 
-The [=channelcount=] and [=samplerate=] fields of [=AudioSampleEntry=] are set to 1 and to indicate 48000, respectively. Parsers SHALL ignore these two fields.
+The [=channelcount=] field of [=AudioSampleEntry=] SHALL be set to 0. 
+The [=samplerate=] field of [=AudioSampleEntry=] SHALL be set to the max sample rate of all the [=Audio Substreams=] in the [=IA Sequence=].
+Parsers SHALL ignore these two fields.
 
 None of [=AudioSampleEntry=]'s optional boxes SHALL be present.
 

--- a/index.bs
+++ b/index.bs
@@ -1828,7 +1828,7 @@ class IASampleEntry extends AudioSampleEntry('iamf') {
 ```
 
 The [=channelcount=] field of [=AudioSampleEntry=] SHALL be set to 0. 
-The [=samplerate=] field of [=AudioSampleEntry=] SHALL be set to the max sample rate of all the [=Audio Substreams=] in the [=IA Sequence=].
+The [=samplerate=] field of [=AudioSampleEntry=] SHALL be set to 0. There SHALL be no [=SamplingRateBox=].
 Parsers SHALL ignore these two fields.
 
 None of [=AudioSampleEntry=]'s optional boxes SHALL be present.


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/pull/533.html" title="Last updated on Jun 27, 2023, 7:38 AM UTC (d35b444)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/533/3318721...d35b444.html" title="Last updated on Jun 27, 2023, 7:38 AM UTC (d35b444)">Diff</a>