### PR TITLE
First draft of merging `obu_redundant_copy` and `obu_trimming_status_…

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -417,13 +417,12 @@ If the syntax element [=obu_type=] is equal to OBU_IA_Sequence_Header, an ordere
 
 ```
 class obu_header() {
-  unsigned int (5) obu_type;
+  unsigned int (6) obu_type;
   unsigned int (1) obu_extra_flag;
-  unsigned int (1) reserved;
   unsigned int (1) obu_extension_flag;
   leb128() obu_size;
 
-  if (obu_trimming_status_flag) {
+  if (obu_extra_flag && (8 <= obu_type && obu_type < 30)) {
     leb128() num_samples_to_trim_at_end;
     leb128() num_samples_to_trim_at_start;
   }
@@ -453,11 +452,11 @@ obu_type: Name of obu_type
 
 <dfn noexport>obu_extra_flag</dfn>
 
-It shall always be set to 0 for the following [=obu_type=] values:
+It SHALL always be set to 0 for the following [=obu_type=] values:
 
 - OBU_IA_Temporal_Delimiter
 
-It may be set to 1 for other [=obu_type=] values.
+It MAY be set to 1 for other [=obu_type=] values.
 
 When [=obu_type=] is:
 

--- a/index.bs
+++ b/index.bs
@@ -411,13 +411,15 @@ If the syntax element [=obu_type=] is equal to OBU_IA_Sequence_Header, an ordere
 
 ## OBU Header Syntax and Semantics ## {#obu-header}
 
+<dfn noexport>obu_redundant_copy</dfn> indicates whether this OBU is a redundant copy of the previous OBU in the IA sequence with the same obu_type. A value of 1 indicates that it is a redundant copy, while a value of 0 indicates that it is not.
+
 <b>Syntax</b>
 
 ```
 class obu_header() {
   unsigned int (5) obu_type;
-  unsigned int (1) obu_redundant_copy;
-  unsigned int (1) obu_trimming_status_flag;
+  unsigned int (1) obu_extra_flag;
+  unsigned int (1) reserved;
   unsigned int (1) obu_extension_flag;
   leb128() obu_size;
 
@@ -449,15 +451,29 @@ obu_type: Name of obu_type
    31   : OBU_IA_Sequence_Header
 </pre>
 
-<dfn noexport>obu_redundant_copy</dfn> indicates whether this OBU is a redundant copy of the previous OBU in the [=IA Sequence=] with the same [=obu_type=]. A value of 1 indicates that it is a redundant copy, while a value of 0 indicates that it is not.
+<dfn noexport>obu_extra_flag</dfn>
 
-It SHALL always be set to 0 for the following [=obu_type=] values:
+It shall always be set to 0 for the following [=obu_type=] values:
 
 - OBU_IA_Temporal_Delimiter
-- OBU_IA_Audio_Frame
-- OBU_IA_Audio_Frame_ID0 to OBU_IA_Audio_Frame_ID17
 
-<dfn noexport>obu_trimming_status_flag</dfn> indicates whether this OBU has audio samples to be trimmed or not. It SHALL be set only when [=obu_type=] is set to OBU_IA_Audio_Frame or OBU_IA_Audio_Frame_ID0 to OBU_IA_Audio_Frame_ID17.
+It may be set to 1 for other [=obu_type=] values.
+
+When [=obu_type=] is:
+
+- OBU_IA_Audio_Frame
+- OBU_IA_Audio_Frame_ID0 to OBU_IA_Audio_Frame_ID21
+
+It indicates that [=num_samples_to_trim_at_start=] and [=num_samples_to_trim_at_end=] are included in the bitstream.
+
+When [=obu_type=] is:
+
+- OBU_IA_Codec_Config
+- OBU_IA_Audio_Element
+- OBU_IA_Mix_Presentation
+- OBU_IA_Parameter_Block
+
+It indicates the value of [=obu_redundant_copy=].
 
 For a given coded [=Audio Substream=], 
 - If an [=Audio Frame OBU=] has its [=num_samples_to_trim_at_start=] field set to a non-zero value N, the decoder SHALL discard the first N audio samples.


### PR DESCRIPTION
…flag`.

First draft of the change discussed in the meeting. There may be more editorial changes, but I think this makes the bitstream changes.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jwcullen/iamf/pull/544.html" title="Last updated on Jun 27, 2023, 11:14 PM UTC (a9dd364)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/544/de8a2cf...jwcullen:a9dd364.html" title="Last updated on Jun 27, 2023, 11:14 PM UTC (a9dd364)">Diff</a>