### PR TITLE
Fix #546: Update obu numbers for reserved and audio_frame_id*

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -404,11 +404,10 @@ class ia_open_bitstream_unit() {
     temporal_delimiter_obu();
   else if (obu_type == OBU_IA_Audio_Frame)
     audio_frame_obu(true);
-  else if (obu_type >= 9 and <= 30)
+  else if (obu_type >= 6 and <= 23)
     audio_frame_obu(false);
-  else if (obu_type == 5 or 6 or 7)
+  else if (obu_type >=24 and <= 30)
     reserved_obu();
-
 }
 ```
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/pull/551.html" title="Last updated on Jun 28, 2023, 8:52 PM UTC (fd85dec)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/551/9e3f2e5...fd85dec.html" title="Last updated on Jun 28, 2023, 8:52 PM UTC (fd85dec)">Diff</a>