### PR TITLE
Fix #545: Expand abbrevs for the IAMF Timing Model figure

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -367,10 +367,10 @@ Within an [=IA Sequence=], all [=Mix Presentation=]s have the same duration, def
 
 The term <dfn noexport>Temporal Unit</dfn> means a set of all [=Audio Frame OBU=]s with the same decode start time and the same duration from all coded [=Audio Substream=]s and all non-redundant [=Parameter Block OBU=]s with the decode start time within the duration.
 
-The below figure shows an example of Timing Model in terms of the decode start times and durations of coded [=Audio Substream=] and [=Parameter Substream=].
+The figure below shows an example of the Timing Model in terms of the decode start times and durations of the coded [=Audio Substream=] and [=Parameter Substream=].
 
 <center><img src="images/IAMF Timing Model.png" style="width:100%; height:auto;"></center>
-<center><figcaption>Example of IAMF Timing Model</figcaption></center>
+<center><figcaption>An example of the IAMF Timing Model. AFO: Audio Frame OBU, PBO: Parameter Block OBU, PT<code>x</code>: time <code>x</code> (ms) on the presentation layer's timeline, DT<code>y</code>: time <code>y</code> (ms) on the decoding layer's timeline.</figcaption></center>
 
 NOTE: For a given decoded [=Audio Substream=] (before trimming) and its associated [=Parameter Substream=](s), a decoder operates 1) or 2). 1) the decoder trims the audio samples to be trimmed of the [=Audio Substream=] after applying the [=Parameter Substream=](s) or 2) the decoder trims the audio samples to be trimmed of the [=Audio Substream=] and the parameter values of the [=Parameter Substream=](s) which are mapped to the audio samples to be trimmed, and then applies its remained [=Parameter Substream=](s) to the [=Audio Substream=] after trimming.
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/pull/555.html" title="Last updated on Jun 29, 2023, 5:24 PM UTC (22f8419)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/555/9e3f2e5...22f8419.html" title="Last updated on Jun 29, 2023, 5:24 PM UTC (22f8419)">Diff</a>