### PR TITLE
Fix #511, explicitly limit decoded leb128() to 32 bits

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2603,12 +2603,6 @@ All of syntax elements conform to [=Syntactic Description Language=] specified i
 
  <b>syntaxName</b> is an unsigned integer which is encoded by <b>leb128()</b>. Its size is limited to 32 bits.
   
- <b>sleb128()</b> <b>syntaxName</b>
-
- <b>sleb128()</b> indicates the type of a signed integer. To encode the following a signed integer <b>syntaxName</b>, it first starts with an N-bit two's complement representation of the signed integer, where N is a multiple of 7, the N-bit representation is broken into groups as for the <b>leb128()</b> encoding.
-
- <b>syntaxName</b> is a signed integer which is encoded by <b>sleb128()</b>. Its size is limited to 32 bits.
- 
  <b>string</b> <b>syntaxName</b>
 
 <b>string</b> indicates a null-terminated (i.e. ending at the first byte set to 0x00), UTF-8 encoded as defined in [[!RFC3629]] and whose length SHALL be limited to 128 bytes. 

--- a/index.bs
+++ b/index.bs
@@ -2599,7 +2599,7 @@ All of syntax elements conform to [=Syntactic Description Language=] specified i
 
  <b>leb128()</b> <b>syntaxName</b>
  
- <b>leb128()</b> indicates the type of an unsigned integer. To encode the following unsigned integer <b>syntaxName</b>, it first represents the integer in binary with an N-bit representation, where N ia a multiple of 7. Then break the integer up into groups of 7 bits. Output one encoded byte for each 7 bits group, from least significant to most significant group. Each byte will have the group in its 7 least significant bits. Set the most significant bit on each byte except the last byte.
+ <b>leb128()</b> indicates the type of an unsigned integer. To encode the following unsigned integer <b>syntaxName</b>, it first represents the integer in binary with an N-bit representation, where N is a multiple of 7. Then break the integer up into groups of 7 bits. Output one encoded byte for each 7 bits group, from least significant to most significant group. Each byte will have the group in its 7 least significant bits. Set the most significant bit on each byte except the last byte.
 
  <b>syntaxName</b> is an unsigned integer which is encoded by <b>leb128()</b>. Its size is limited to 32 bits.
   

--- a/index.bs
+++ b/index.bs
@@ -2599,15 +2599,15 @@ All of syntax elements conform to [=Syntactic Description Language=] specified i
 
  <b>leb128()</b> <b>syntaxName</b>
  
- <b>leb128()</b> indicates the type of an unsigned integer. It indicates the following unsigned integer <b>syntaxName</b> is encoded by [=leb128()=] specified in [[!AV1-Convention]].
- 
- <b>syntaxName</b> is an unsigned integer which is encoded by [=leb128()=] specified in [[!AV1-Convention]].
- 
+ <b>leb128()</b> indicates the type of an unsigned integer. To encode the following unsigned integer <b>syntaxName</b>, it first represents the integer in binary. Then zero extends the integer up to a multiple of 7 bits (such that if the number is non-zero, the most significant 7 bits are not all 0). Break the integer up into groups of 7 bits. Output one encoded byte for each 7 bits group, from least significant to most significant group. Each byte will have the group in its 7 least significant bits. Set the most significant bit on each byte except the last byte. The integer zero is encoded as a single byte 0x00.
+
+ <b>syntaxName</b> is an unsigned integer which is encoded by <b>leb128()</b>. Its size is limited to 32 bits.
+  
  <b>sleb128()</b> <b>syntaxName</b>
 
- <b>sleb128()</b> indicates the type of an signed integer. It indicates the following signed integer <b>syntaxName</b> is encoded by [=leb128()=] specified in [[!AV1-Convention]].
- 
- <b>syntaxName</b> is an signed integer which is encoded by [=leb128()=] specified in [[!AV1-Convention]].
+ <b>sleb128()</b> indicates the type of a signed integer. To encode the following a signed integer <b>syntaxName</b>, it first starts with an N-bit two's complement representation of the signed integer, where N is a multiple of 7, the N-bit representation is broken into groups as for the <b>leb128()</b> encoding.
+
+ <b>syntaxName</b> is a signed integer which is encoded by <b>sleb128()</b>. Its size is limited to 32 bits.
  
  <b>string</b> <b>syntaxName</b>
 

--- a/index.bs
+++ b/index.bs
@@ -2599,7 +2599,7 @@ All of syntax elements conform to [=Syntactic Description Language=] specified i
 
  <b>leb128()</b> <b>syntaxName</b>
  
- <b>leb128()</b> indicates the type of an unsigned integer. To encode the following unsigned integer <b>syntaxName</b>, it first represents the integer in binary. Then zero extends the integer up to a multiple of 7 bits (such that if the number is non-zero, the most significant 7 bits are not all 0). Break the integer up into groups of 7 bits. Output one encoded byte for each 7 bits group, from least significant to most significant group. Each byte will have the group in its 7 least significant bits. Set the most significant bit on each byte except the last byte. The integer zero is encoded as a single byte 0x00.
+ <b>leb128()</b> indicates the type of an unsigned integer. To encode the following unsigned integer <b>syntaxName</b>, it first represents the integer in binary with an N-bit representation, where N ia a multiple of 7. Then break the integer up into groups of 7 bits. Output one encoded byte for each 7 bits group, from least significant to most significant group. Each byte will have the group in its 7 least significant bits. Set the most significant bit on each byte except the last byte.
 
  <b>syntaxName</b> is an unsigned integer which is encoded by <b>leb128()</b>. Its size is limited to 32 bits.
   


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/pull/558.html" title="Last updated on Jul 4, 2023, 9:29 PM UTC (9c07722)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/558/9e3f2e5...9c07722.html" title="Last updated on Jul 4, 2023, 9:29 PM UTC (9c07722)">Diff</a>