### PR TITLE
Remove profile restriction on param_definition_mode

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1738,8 +1738,6 @@ Common restrictions on the [=IA Sequence=] for all profiles specified in this ve
 NOTE: This behavior is to allow future versions of this specification to define new profiles that support a number of audio elements and/or a number of sub-mixes greater than those recommended in this profile, while still permitting streams compliant to these new profiles to be processed by parsers compliant to the profiles defined in this version of the specification.
 
 - When [=num_layers=] = 1, DemixingParameDefinion() for demixng MAY be present in the [=Audio Element OBU=] and IA decoders MAY use the (default) parameter data for demixing for (dynamic) down-mixing.
-- All parameter definitons except DemixingParamDefinition() and ReconGainParamDefinition() SHALL have the same [=param_definition_mode=].
-	- When [=param_definition_mode=] = 0, [=duration=], [=num_subblocks=], [=constant_subblock_duration=] and [=subblock_duration=] SHALL be same in all parameter definitions, respectively.
 
 
 ## IA Simple Profile ## {#profiles-simple}


### PR DESCRIPTION
This is an outdated restriction that prevents flexibility in providing parameter blocks that may have different duration-related metadata.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/pull/559.html" title="Last updated on Jun 30, 2023, 7:21 PM UTC (a82fb8b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/559/9e3f2e5...a82fb8b.html" title="Last updated on Jun 30, 2023, 7:21 PM UTC (a82fb8b)">Diff</a>