### PR TITLE
Fix #516, define audio_substream_id_in_bitstream

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1611,6 +1611,8 @@ class audio_frame_obu(audio_substream_id_in_bitstream) {
 
 <b>Semantics</b>
 
+Where <b>audio_substream_id_in_bitstream</b> is not a syntax in an [=IA Sequence=] but indicates a status whether this OBU payload is including explicitly [=audio_substream_id=]. It is `true` for [=obu_type=] = OBU_IA_Audio_Frame and `false` for [=obu_type=] = OBU_IA_Audio_Frame_ID0, OBU_IA_Audio_Frame_ID1, ..., or OBU_IA_Audio_Frame_ID17.
+
 <dfn noexport>explicit_audio_substream_id</dfn> defines the [=audio_substream_id=] of this frame. The value SHALL be greater than 17. When this field is not present [=audio_substream_id=] is implicit and is defined as a value from 0 to 17 for OBU_IA_Audio_Frame_ID0 to OBU_IA_Audio_Frame_ID17 respectively.
 
 NOTE: The first 18 [=Audio Substream=]s in an [=IA Sequence=] MAY use the OBU types OBU_IA_Audio_Frame_ID0 to OBU_IA_Audio_Frame_ID17, which have predefined [=audio_substream_id=]s associated with them. This reduces bitrate by avoiding the extra [=explicit_audio_substream_id=] field in the bitstream.


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/pull/560.html" title="Last updated on Jul 4, 2023, 9:58 PM UTC (824014a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/560/9e3f2e5...824014a.html" title="Last updated on Jul 4, 2023, 9:58 PM UTC (824014a)">Diff</a>