### PR TITLE
Fix #517, clarification on default_demixing_info_parameter_data()

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -633,6 +633,11 @@ class audio_element_obu() {
 ```
 class DemixingParamDefinition() extends ParamDefinition() {
   default_demixing_info_parameter_data();
+}
+```
+
+```
+class default_demixing_info_parameter_data() extends demixing_info_parameter_data() {
   unsigned int (4) default_w;
   unsigned int (4) reserved;
 }
@@ -732,12 +737,13 @@ NOTE: For a given [=audio_element_type=], a future version of the specification 
 
 <dfn noexport>audio_element_config_bytes</dfn> represents reserved bytes for future use when new [=audio_element_type=] values are defined. Parsers compliant to this version of the specification SHALL ignore these bytes.
 
+<dfn noexport>default_demixing_info_parameter_data()</dfn> is a class that provides the default parameter data for demixing to apply to all audio samples when there are no [=Parameter Block OBU=]s (with [=parameter_id=] defined in this DemixingParamDefinition()) provided.
+- In this class, [=w_idx_offset=] of the [=demixing_info_parameter_data()=] SHALL be ignored.
+- Instead of that, [=default_w=] directly indicates the weight value w(k).
 
-<dfn noexport>default_demixing_info_parameter_data()</dfn> and <dfn noexport>default_w</dfn> specify the default parameter data for demixing to apply to all audio samples when there are no [=Parameter Block OBU=]s (with [=parameter_id=] defined in this DemixingParamDefinition()) provided.
-- [=default_demixing_info_parameter_data()=] conforms to [=demixing_info_parameter_data()=] except that [=w_idx_offset=] SHALL be ignored.
-- Instead of that, [=default_w=] directly indicates the weight value w(k) for [=TF2toT2 de-mixer=] specified in [[#processing-scalablechannelaudio-demixer]].
+<dfn noexport>default_w</dfn> indicates the weight value w(k) for [=TF2toT2 de-mixer=] specified in [[#processing-scalablechannelaudio-demixer]].
 
-Mapping of default_w to w(k) SHOULD be as follows:
+Mapping of [=default_w=] to w(k) SHOULD be as follows:
 <pre class = "def">
  default_w :   w(k)
     0      :    0


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/pull/561.html" title="Last updated on Jul 4, 2023, 10:10 PM UTC (cade0f6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/561/9e3f2e5...cade0f6.html" title="Last updated on Jul 4, 2023, 10:10 PM UTC (cade0f6)">Diff</a>