### PR TITLE
Fix #521, all IA Samples are marked as sync samples

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1908,7 +1908,7 @@ Parsers SHALL ignore these two fields.
 ### IA Sample Format ### {#iasampleformat}
 
 For tracks using the [=IASampleEntry=], an <dfn noexport>IA Sample</dfn> has the following constraints:
-- ALL IA Samples SHALL be marked as sync samples.
+- All IA Samples SHALL be marked as sync samples.
 - One IA Sample data SHALL be one [=Temporal Unit=] and SHALL NOT contain [=Temporal Delimiter OBU=].
 - The decode duration of an IA Sample SHALL equal the duration of the underlying [=Temporal Unit=], i.e. the decode duration of the [=Audio Frame OBU=].
 

--- a/index.bs
+++ b/index.bs
@@ -1908,6 +1908,7 @@ Parsers SHALL ignore these two fields.
 ### IA Sample Format ### {#iasampleformat}
 
 For tracks using the [=IASampleEntry=], an <dfn noexport>IA Sample</dfn> has the following constraints:
+- ALL IA Samples SHALL be marked as sync samples.
 - One IA Sample data SHALL be one [=Temporal Unit=] and SHALL NOT contain [=Temporal Delimiter OBU=].
 - The decode duration of an IA Sample SHALL equal the duration of the underlying [=Temporal Unit=], i.e. the decode duration of the [=Audio Frame OBU=].
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/pull/563.html" title="Last updated on Jul 5, 2023, 9:37 PM UTC (b95604d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/563/9e3f2e5...b95604d.html" title="Last updated on Jul 5, 2023, 9:37 PM UTC (b95604d)">Diff</a>