### PR TITLE
configOBUs -> config_obus for variable naming consistency

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1871,15 +1871,15 @@ The result of encapsulating an [=IA Sequence=] into an [[!ISOBMFF]] file is as f
 
 - If there are audio samples to be trimmed at the start or at the end, then 'edts' and 'elst' boxes SHALL be present to reflect the trimming status.
 - Sample Entry
-	- For an [=IA Sample=], the [=Descriptors=] required for processing the samples SHALL be only one and SHALL be the [=configOBUs=] of the associated one single sample entry. 
+	- For an [=IA Sample=], the [=Descriptors=] required for processing the samples SHALL be only one and SHALL be the [=config_obus=] of the associated one single sample entry.
 	
-NOTE: Multiple sample entries may be used in a track, for example when the track is the concatenation of multiple tracks or multiple [=IA Sequence=]s and some [=IA Sample=]s have different [=configOBUs=] values.
+NOTE: Multiple sample entries may be used in a track, for example when the track is the concatenation of multiple tracks or multiple [=IA Sequence=]s and some [=IA Sample=]s have different [=config_obus=] values.
 
 - Decoding Time to IA Sample
 	- 'stts' or 'trun' box SHALL indicate the number of audio samples which [=IA Sample=] includes (i.e. the duration of [=IA Sample=]). 
 	- The duration of [=IA Sample=] is duration including audio samples trimmed at the beginning but excluding audio samples trimmed at the end. 
 - Sample Group
-	- When [=codec_id=] is set to 'Opus' or 'mp4a', in an IA Track, every sample SHALL be associated with a sample group of type 'roll'. The [=roll_distance=] value SHALL equal to the value of the [=audio_roll_distance=] field in the [=Codec Config OBU=] stored in the [=configOBUs=] array in the sample entry.
+	- When [=codec_id=] is set to 'Opus' or 'mp4a', in an IA Track, every sample SHALL be associated with a sample group of type 'roll'. The [=roll_distance=] value SHALL equal to the value of the [=audio_roll_distance=] field in the [=Codec Config OBU=] stored in the [=config_obus=] array in the sample entry.
 - Composition Time Stamp (CTS)
 	- For each IA Sample, CTS = DTS (Decoding Time Stamp), and as a consequence, the 'ctts' box (and similar signaling in movie fragments) SHALL not be used.
 
@@ -1892,13 +1892,13 @@ NOTE: Multiple sample entries may be used in a track, for example when the track
 	Quantity:          One or more.
 </pre>
 
-<dfn noexport>IASampleEntry</dfn> identifies that the track contains [=IA Sample=]s, and contains [=configOBUs=].
+<dfn noexport>IASampleEntry</dfn> identifies that the track contains [=IA Sample=]s, and contains [=config_obus=].
 
 <b>Syntax</b>
 
 ```
 class IASampleEntry extends AudioSampleEntry('iamf') {
-  unsigned int (8) configOBUs[];
+  unsigned int (8) config_obus[];
 }
 ```
 
@@ -1908,7 +1908,7 @@ Parsers SHALL ignore these two fields.
 
 <b>Semantics</b>
 
-<dfn noexport>configOBUs</dfn> SHALL contain the following OBUs in order.
+<dfn noexport>config_obus</dfn> SHALL contain the following OBUs in order.
 - [=IA Sequence Header OBU=]
 - [=Codec Config OBU=]
 - One or more [=Audio Element OBU=]s
@@ -1981,7 +1981,7 @@ This section provides a guideline for IAMF parser to reconstruct [=IA Sequence=]
 When IAMF parser feeds the reconstructed [=IA Sequence=]s to OBU parser, [=Descriptors=] shall be placed at the first and followed by [=Temporal Unit=]s.
 
 During decapsulation process, IAMF file is decapsulated into an [=IA Sequence=]s which conform to [[#obu-syntax]] as follows:
-- Step1: Take the [=configOBUs=] from an [=IASampleEntry=] as the [=Descriptors=] of the [=IA Sequence=].
+- Step1: Take the [=config_obus=] from an [=IASampleEntry=] as the [=Descriptors=] of the [=IA Sequence=].
 - Step2: Take the jth sample, which is associated with the [=IASampleEntry=], as the jth [=Temporal Unit=].
 	- If [=Temporal Delimiter OBU=] is inserted in front of the [=Temporal Unit=], then every [=Temporal Unit=] has [=Temporal Delimiter OBU=]. Otherwise,no [=Temporal Unit=] has [=Temporal Delimiter OBU=].
 - Step3: Place the [=Descriptors=], and followed by [=Temporal Unit=]s in order (j = 1, 2, …, m), to reconstruct the [=IA Sequence=].


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/pull/596.html" title="Last updated on Jul 6, 2023, 9:49 PM UTC (19c46c1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/596/75175af...19c46c1.html" title="Last updated on Jul 6, 2023, 9:49 PM UTC (19c46c1)">Diff</a>