### PR TITLE
Apply restrictions to FLAC `decoder_config`.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1703,7 +1703,7 @@ The sample rate used for computing offsets SHALL be the rate indicated by the [=
 - [=maximum block size=] SHALL be set to [=num_samples_per_frame=].
 - [=minimum frame size=] SHOULD be set to 0.
 - [=maximum frame size=] SHOULD be set to 0.
-- [=number of channels=] SHALL be set to 2. [=number of channels=] can be ignored because the real value can be determined from the [=Audio Element OBU=].
+- [=number of channels=] SHALL be set to 1. [=number of channels=] can be ignored because the real value can be determined from the [=Audio Element OBU=].
 - [=MD5 signature=] SHOULD be set to 0.
 
 The format of [=audio_frame()=] is [=FRAME=] of [[!FLAC]], which is composed of [=FRAME_HEADER=], followed by [=SUBFRAME=](s) (one [=SUBFRAME=] per channel) and followed by [=FRAME_FOOTER=].

--- a/index.bs
+++ b/index.bs
@@ -1700,8 +1700,8 @@ The sample rate used for computing offsets SHALL be the rate indicated by the [=
 [=decoder_config()=] for FLAC are the [=METADATA_BLOCK=]s of [[!FLAC]]. The [=METADATA_BLOCK_STREAMINFO=] has the following constraints:
 - [=minimum block size=] block SHALL be set to [=num_samples_per_frame=].
 - [=maximum block size=] block SHALL be set to [=num_samples_per_frame=].
-- [=minimum frame size=] block SHALL be set to 0.
-- [=maximum frame size=] block SHALL be set to 0.
+- [=minimum frame size=] block SHOULD be set to 0.
+- [=maximum frame size=] block SHOULD be set to 0.
 - [=number of channels=] block SHALL be set to 2. [=number of channels=] can be ignored because the real value can be determined from the [=Audio Element OBU=].
 
 

--- a/index.bs
+++ b/index.bs
@@ -127,6 +127,10 @@ url: https://xiph.org/flac/format.html; spec: FLAC; type: dfn;
 	text: maximum frame size
 	text: number of channels
 	text: MD5 signature
+	text: Block size in inter-channel samples
+	text: Sample rate
+	text: Channel assignment
+	text: Sample size in bits
 
 url: https://xiph.org/flac/format.html; spec: FLAC; type: property;
 	text: fLaC
@@ -1698,15 +1702,19 @@ The sample rate used for computing offsets SHALL be the rate indicated by the [=
 
 [=codec_id=] SHALL be 'fLaC', the FLAC stream marker in ASCII, meaning byte 0 of the stream is 0x66, followed by 0x4C 0x61 0x43.
 
-[=decoder_config()=] for FLAC are the [=METADATA_BLOCK=]s of [[!FLAC]]. The [=METADATA_BLOCK_STREAMINFO=] has the following constraints:
+[=decoder_config()=] for FLAC is the [=METADATA_BLOCK=]s of [[!FLAC]] for mono or stereo channels. The [=METADATA_BLOCK_STREAMINFO=] has the following constraints:
 - [=minimum block size=] SHALL be set to [=num_samples_per_frame=].
 - [=maximum block size=] SHALL be set to [=num_samples_per_frame=].
 - [=minimum frame size=] SHOULD be set to 0.
 - [=maximum frame size=] SHOULD be set to 0.
-- [=number of channels=] SHALL be set to 1. [=number of channels=] can be ignored because the real value can be determined from the [=Audio Element OBU=].
+- [=number of channels=] SHALL be set to 1. [=number of channels=] can be ignored because the real value can be determined from the [=Audio Element OBU=] and from the [=Frame_Header=].
 - [=MD5 signature=] SHOULD be set to 0.
 
-The format of [=audio_frame()=] is [=FRAME=] of [[!FLAC]], which is composed of [=FRAME_HEADER=], followed by [=SUBFRAME=](s) (one [=SUBFRAME=] per channel) and followed by [=FRAME_FOOTER=].
+The format of [=audio_frame()=] is [=FRAME=] of [[!FLAC]] which contains only one single frame of mono or stereo channels with the following constraints.
+- [=Block size in inter-channel samples=] in the [=FRAME_HEADER=] SHALL be set to [=num_samples_per_frame=].
+- [=Sample rate=] in the [=FRAME_HEADER=] SHALL indicate the same sample rate defined in the [=METADATA_BLOCK_STREAMINFO=].
+- [=Channel assignment=] in the [=FRAME_HEADER=] SHALL be set to 0 or 1 to indicate that the [=FRAME=] contains mono channel or stereo channels, respectively.
+- [=Sample size in bits=] in the [=FRAME_HEADER=] SHALL indicate the same sample size defined in the [=METADATA_BLOCK_STREAMINFO=]. 
 
 The sample rate used for computing offsets SHALL be the sampling rate indicated in the [=METADATA_BLOCK=].
 

--- a/index.bs
+++ b/index.bs
@@ -116,10 +116,16 @@ url: https://en.wikipedia.org/wiki/Q_(number_format); spec: Q-Format; type: dfn;
 
 url: https://xiph.org/flac/format.html; spec: FLAC; type: dfn;
 	text: METADATA_BLOCK
+	text: METADATA_BLOCK_STREAMINFO
 	text: FRAME
 	text: FRAME_HEADER
 	text: SUBFRAME
 	text: FRAME_FOOTER
+	text: minimum block size
+	text: maximum block size
+	text: minimum frame size
+	text: maximum frame size
+	text: number of channels
 
 url: https://xiph.org/flac/format.html; spec: FLAC; type: property;
 	text: fLaC
@@ -1691,7 +1697,13 @@ The sample rate used for computing offsets SHALL be the rate indicated by the [=
 
 [=codec_id=] SHALL be 'fLaC', the FLAC stream marker in ASCII, meaning byte 0 of the stream is 0x66, followed by 0x4C 0x61 0x43.
 
-[=decoder_config()=] for FLAC is [=METADATA_BLOCK=] of [[!FLAC]].
+[=decoder_config()=] for FLAC are the [=METADATA_BLOCK=]s of [[!FLAC]]. The [=METADATA_BLOCK_STREAMINFO=] has the following constraints:
+- [=minimum block size=] block SHALL be set to [=num_samples_per_frame=].
+- [=maximum block size=] block SHALL be set to [=num_samples_per_frame=].
+- [=minimum frame size=] block SHALL be set to 0.
+- [=maximum frame size=] block SHALL be set to 0.
+- [=number of channels=] block SHALL be set to 2. [=number of channels=] can be ignored because the real value can be determined from the [=Audio Element OBU=].
+
 
 The format of [=audio_frame()=] is [=FRAME=] of [[!FLAC]], which is composed of [=FRAME_HEADER=], followed by [=SUBFRAME=](s) (one [=SUBFRAME=] per channel) and followed by [=FRAME_FOOTER=].
 

--- a/index.bs
+++ b/index.bs
@@ -126,6 +126,7 @@ url: https://xiph.org/flac/format.html; spec: FLAC; type: dfn;
 	text: minimum frame size
 	text: maximum frame size
 	text: number of channels
+	text: MD5 signature
 
 url: https://xiph.org/flac/format.html; spec: FLAC; type: property;
 	text: fLaC
@@ -1698,12 +1699,12 @@ The sample rate used for computing offsets SHALL be the rate indicated by the [=
 [=codec_id=] SHALL be 'fLaC', the FLAC stream marker in ASCII, meaning byte 0 of the stream is 0x66, followed by 0x4C 0x61 0x43.
 
 [=decoder_config()=] for FLAC are the [=METADATA_BLOCK=]s of [[!FLAC]]. The [=METADATA_BLOCK_STREAMINFO=] has the following constraints:
-- [=minimum block size=] block SHALL be set to [=num_samples_per_frame=].
-- [=maximum block size=] block SHALL be set to [=num_samples_per_frame=].
-- [=minimum frame size=] block SHOULD be set to 0.
-- [=maximum frame size=] block SHOULD be set to 0.
-- [=number of channels=] block SHALL be set to 2. [=number of channels=] can be ignored because the real value can be determined from the [=Audio Element OBU=].
-
+- [=minimum block size=] SHALL be set to [=num_samples_per_frame=].
+- [=maximum block size=] SHALL be set to [=num_samples_per_frame=].
+- [=minimum frame size=] SHOULD be set to 0.
+- [=maximum frame size=] SHOULD be set to 0.
+- [=number of channels=] SHALL be set to 2. [=number of channels=] can be ignored because the real value can be determined from the [=Audio Element OBU=].
+- [=MD5 signature=] SHOULD be set to 0.
 
 The format of [=audio_frame()=] is [=FRAME=] of [[!FLAC]], which is composed of [=FRAME_HEADER=], followed by [=SUBFRAME=](s) (one [=SUBFRAME=] per channel) and followed by [=FRAME_FOOTER=].
 


### PR DESCRIPTION
Apply restrictions to FLAC `decoder_config` similar to Opus `decoder_config`.

  - The `decoder_config` is shared between substreams. Some values do not make sense to apply to all substreams.
  
---------

Opus has these types of restrictions too. For example if we have a 5.1 FLAC audio element there will be an L/R stream with 2 channels and an LFE channel with 1 channel. They will both share the same `decoder_config`. 

The `minimum/maximum_block_size` restriction makes sure FLAC frames contain the same number of samples. The `minimum/maximum_frame_size` recommendation is because these values affect multiple sub streams that may be encoded with a different number of bytes.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jwcullen/iamf/pull/611.html" title="Last updated on Jul 13, 2023, 3:14 AM UTC (55288a3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/611/75175af...jwcullen:55288a3.html" title="Last updated on Jul 13, 2023, 3:14 AM UTC (55288a3)">Diff</a>