### PR TITLE
Fix #614, section link correction for ChannelGroup in section 3.6

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -678,7 +678,7 @@ Let a particular [=ChannelGroup=]'s [=Aduio Substream]s be indexed as [<dfn noex
 [[1, 1], [1, 2], ..., [1, N_1], [2, 1], [2, 2], ..., [2, N_2], ..., [C, 1], [C, 2], ..., [C, N_c]]
 ```
 
-A [=ChannelGroup=] generation rule is described in [[#iamfgeneration-scalablechannelaudio-channelgroupgenerationrule]]. The order of the [=Audio Substream=]s in each [=ChannelGroup=]., i.e. the semantics of n_c, is specified in [[#syntax-scalable-channel-layout-config]].
+A [=ChannelGroup=] generation rule is described in [[#iamfgeneration-scalablechannelaudio-channelgroupgenerationrule]]. The order of the [=Audio Substream=]s in each [=ChannelGroup=], the semantics of n_c, is specified in [[#syntax-scalable-channel-layout-config]].
 
 
 <dfn noexport>num_parameters</dfn> specifies the number of [=Parameter Substream=]s that are used by the algorithms specified in this [=Audio Element=].

--- a/index.bs
+++ b/index.bs
@@ -678,7 +678,7 @@ Let a particular [=ChannelGroup=]'s [=Aduio Substream]s be indexed as [<dfn noex
 [[1, 1], [1, 2], ..., [1, N_1], [2, 1], [2, 2], ..., [2, N_2], ..., [C, 1], [C, 2], ..., [C, N_c]]
 ```
 
-A [=ChannelGroup=] is defined in [[#iamfgeneration]]. The order of the [=Audio Substream=]s in each [=ChannelGroup=]., i.e. the semantics of n_c, is specified in [[#syntax-scalable-channel-layout-config]].
+A [=ChannelGroup=] generation rule is described in [[#iamfgeneration-scalablechannelaudio-channelgroupgenerationrule]]. The order of the [=Audio Substream=]s in each [=ChannelGroup=]., i.e. the semantics of n_c, is specified in [[#syntax-scalable-channel-layout-config]].
 
 
 <dfn noexport>num_parameters</dfn> specifies the number of [=Parameter Substream=]s that are used by the algorithms specified in this [=Audio Element=].


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/pull/616.html" title="Last updated on Jul 13, 2023, 5:32 AM UTC (377a785)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/616/f047a0f...377a785.html" title="Last updated on Jul 13, 2023, 5:32 AM UTC (377a785)">Diff</a>