### PR TITLE
Fix rebase error preventing build due to duplicate loudness_info()

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1297,7 +1297,7 @@ When a value for [=layout_type=] or [=sound_system=] is not supported, parsers c
 
 ### Loudness Info Syntax and Semantics ### {#obu-mixpresentation-loudness}
 
-<dfn noexport>loudness_info()</dfn> provides loudness information for a given audio signal.
+[=loudness_info()=] provides loudness information for a given audio signal.
 
 All signed values are stored as signed Q7.8 fixed-point values (in [[!Q-Format]]).
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jul 18, 2023, 12:00 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2FAOMediaCodec%2Fiamf%2F38eeeb859bf5e238b369cadbce3cf502a6dc9d46%2Findex.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 2.
Your document appears to use spaces to indent, but line 17 starts with tabs.
Your document appears to use spaces to indent, but line 18 starts with tabs.
Your document appears to use spaces to indent, but line 19 starts with tabs.
Your document appears to use spaces to indent, but line 20 starts with tabs.
Your document appears to use spaces to indent, but line 21 starts with tabs.
Your document appears to use spaces to indent, but line 22 starts with tabs.
Your document appears to use spaces to indent, but line 25 starts with tabs.
Your document appears to use spaces to indent, but line 26 starts with tabs.
Your document appears to use spaces to indent, but line 27 starts with tabs.
Your document appears to use spaces to indent, but line 28 starts with tabs.
Your document appears to use spaces to indent, but line 29 starts with tabs.
Your document appears to use spaces to indent, but line 30 starts with tabs.
Your document appears to use spaces to indent, but line 31 starts with tabs.
Your document appears to use spaces to indent, but line 32 starts with tabs.
Your document appears to use spaces to indent, but line 35 starts with tabs.
Your document appears to use spaces to indent, but line 36 starts with tabs.
Your document appears to use spaces to indent, but line 39 starts with tabs.
Your document appears to use spaces to indent, but line 40 starts with tabs.
Your document appears to use spaces to indent, but line 41 starts with tabs.
Your document appears to use spaces to indent, but line 44 starts with tabs.
Your document appears to use spaces to indent, but line 45 starts with tabs.
Your document appears to use spaces to indent, but line 46 starts with tabs.
Your document appears to use spaces to indent, but line 47 starts with tabs.
Your document appears to use spaces to indent, but line 48 starts with tabs.
Your document appears to use spaces to indent, but line 49 starts with tabs.
Your document appears to use spaces to indent, but line 53 starts with tabs.
Your document appears to use spaces to indent, but line 54 starts with tabs.
Your document appears to use spaces to indent, but line 57 starts with tabs.
Your document appears to use spaces to indent, but line 58 starts with tabs.
Your document appears to use spaces to indent, but line 59 starts with tabs.
Your document appears to use spaces to indent, but line 60 starts with tabs.
Your document appears to use spaces to indent, but line 61 starts with tabs.
Your document appears to use spaces to indent, but line 62 starts with tabs.
Your document appears to use spaces to indent, but line 65 starts with tabs.
Your document appears to use spaces to indent, but line 66 starts with tabs.
Your document appears to use spaces to indent, but line 67 starts with tabs.
Your document appears to use spaces to indent, but line 68 starts with tabs.
Your document appears to use spaces to indent, but line 69 starts with tabs.
Your document appears to use spaces to indent, but line 70 starts with tabs.
Your document appears to use spaces to indent, but line 71 starts with tabs.
Your document appears to use spaces to indent, but line 72 starts with tabs.
Your document appears to use spaces to indent, but line 75 starts with tabs.
Your document appears to use spaces to indent, but line 78 starts with tabs.
Your document appears to use spaces to indent, but line 79 starts with tabs.
Your document appears to use spaces to indent, but line 82 starts with tabs.
Your document appears to use spaces to indent, but line 85 starts with tabs.
Your document appears to use spaces to indent, but line 88 starts with tabs.
Your document appears to use spaces to indent, but line 89 starts with tabs.
Your document appears to use spaces to indent, but line 90 starts with tabs.
Your document appears to use spaces to indent, but line 91 starts with tabs.
Your document appears to use spaces to indent, but line 92 starts with tabs.
Your document appears to use spaces to indent, but line 95 starts with tabs.
Your document appears to use spaces to indent, but line 98 starts with tabs.
Your document appears to use spaces to indent, but line 101 starts with tabs.
Your document appears to use spaces to indent, but line 104 starts with tabs.
Your document appears to use spaces to indent, but line 105 starts with tabs.
Your document appears to use spaces to indent, but line 106 starts with tabs.
Your document appears to use spaces to indent, but line 107 starts with tabs.
Your document appears to use spaces to indent, but line 108 starts with tabs.
Your document appears to use spaces to indent, but line 109 starts with tabs.
Your document appears to use spaces to indent, but line 110 starts with tabs.
Your document appears to use spaces to indent, but line 111 starts with tabs.
Your document appears to use spaces to indent, but line 112 starts with tabs.
Your document appears to use spaces to indent, but line 113 starts with tabs.
Your document appears to use spaces to indent, but line 114 starts with tabs.
Your document appears to use spaces to indent, but line 117 starts with tabs.
Your document appears to use spaces to indent, but line 120 starts with tabs.
Your document appears to use spaces to indent, but line 123 starts with tabs.
Your document appears to use spaces to indent, but line 124 starts with tabs.
Your document appears to use spaces to indent, but line 125 starts with tabs.
Your document appears to use spaces to indent, but line 126 starts with tabs.
Your document appears to use spaces to indent, but line 127 starts with tabs.
Your document appears to use spaces to indent, but line 128 starts with tabs.
Your document appears to use spaces to indent, but line 129 starts with tabs.
Your document appears to use spaces to indent, but line 130 starts with tabs.
Your document appears to use spaces to indent, but line 131 starts with tabs.
Your document appears to use spaces to indent, but line 132 starts with tabs.
Your document appears to use spaces to indent, but line 133 starts with tabs.
Your document appears to use spaces to indent, but line 134 starts with tabs.
Your document appears to use spaces to indent, but line 135 starts with tabs.
Your document appears to use spaces to indent, but line 136 starts with tabs.
Your document appears to use spaces to indent, but line 137 starts with tabs.
Your document appears to use spaces to indent, but line 138 starts with tabs.
Your document appears to use spaces to indent, but line 141 starts with tabs.
Your document appears to use spaces to indent, but line 144 starts with tabs.
Your document appears to use spaces to indent, but line 145 starts with tabs.
Your document appears to use spaces to indent, but line 146 starts with tabs.
Your document appears to use spaces to indent, but line 148 starts with tabs.
Your document appears to use spaces to indent, but line 154 starts with tabs.
Your document appears to use spaces to indent, but line 155 starts with tabs.
Your document appears to use spaces to indent, but line 156 starts with tabs.
Your document appears to use spaces to indent, but line 157 starts with tabs.
Your document appears to use spaces to indent, but line 158 starts with tabs.
Your document appears to use spaces to indent, but line 159 starts with tabs.
Your document appears to use spaces to indent, but line 160 starts with tabs.
Your document appears to use spaces to indent, but line 161 starts with tabs.
Your document appears to use spaces to indent, but line 162 starts with tabs.
Your document appears to use spaces to indent, but line 163 starts with tabs.
Your document appears to use spaces to indent, but line 164 starts with tabs.
Your document appears to use spaces to indent, but line 165 starts with tabs.
Your document appears to use spaces to indent, but line 166 starts with tabs.
Your document appears to use spaces to indent, but line 167 starts with tabs.
Your document appears to use spaces to indent, but line 168 starts with tabs.
Your document appears to use spaces to indent, but line 169 starts with tabs.
Your document appears to use spaces to indent, but line 170 starts with tabs.
Your document appears to use spaces to indent, but line 171 starts with tabs.
Your document appears to use spaces to indent, but line 172 starts with tabs.
Your document appears to use spaces to indent, but line 173 starts with tabs.
Your document appears to use spaces to indent, but line 174 starts with tabs.
Your document appears to use spaces to indent, but line 175 starts with tabs.
Your document appears to use spaces to indent, but line 176 starts with tabs.
Your document appears to use spaces to indent, but line 177 starts with tabs.
Your document appears to use spaces to indent, but line 178 starts with tabs.
Your document appears to use spaces to indent, but line 179 starts with tabs.
Your document appears to use spaces to indent, but line 180 starts with tabs.
Your document appears to use spaces to indent, but line 181 starts with tabs.
Your document appears to use spaces to indent, but line 182 starts with tabs.
Your document appears to use spaces to indent, but line 183 starts with tabs.
Your document appears to use spaces to indent, but line 184 starts with tabs.
Your document appears to use spaces to indent, but line 185 starts with tabs.
Your document appears to use spaces to indent, but line 186 starts with tabs.
Your document appears to use spaces to indent, but line 187 starts with tabs.
Your document appears to use spaces to indent, but line 188 starts with tabs.
Your document appears to use spaces to indent, but line 189 starts with tabs.
Your document appears to use spaces to indent, but line 190 starts with tabs.
Your document appears to use spaces to indent, but line 191 starts with tabs.
Your document appears to use spaces to indent, but line 192 starts with tabs.
Your document appears to use spaces to indent, but line 193 starts with tabs.
Your document appears to use spaces to indent, but line 194 starts with tabs.
Your document appears to use spaces to indent, but line 195 starts with tabs.
Your document appears to use spaces to indent, but line 196 starts with tabs.
Your document appears to use spaces to indent, but line 197 starts with tabs.
Your document appears to use spaces to indent, but line 198 starts with tabs.
Your document appears to use spaces to indent, but line 199 starts with tabs.
Your document appears to use spaces to indent, but line 200 starts with tabs.
Your document appears to use spaces to indent, but line 201 starts with tabs.
Your document appears to use spaces to indent, but line 202 starts with tabs.
Your document appears to use spaces to indent, but line 203 starts with tabs.
Your document appears to use spaces to indent, but line 204 starts with tabs.
Your document appears to use spaces to indent, but line 205 starts with tabs.
Your document appears to use spaces to indent, but line 206 starts with tabs.
Your document appears to use spaces to indent, but line 207 starts with tabs.
Your document appears to use spaces to indent, but line 208 starts with tabs.
Your document appears to use spaces to indent, but line 209 starts with tabs.
Your document appears to use spaces to indent, but line 210 starts with tabs.
Your document appears to use spaces to indent, but line 211 starts with tabs.
Your document appears to use spaces to indent, but line 212 starts with tabs.
Your document appears to use spaces to indent, but line 213 starts with tabs.
Your document appears to use spaces to indent, but line 214 starts with tabs.
Your document appears to use spaces to indent, but line 215 starts with tabs.
Your document appears to use spaces to indent, but line 216 starts with tabs.
Your document appears to use spaces to indent, but line 217 starts with tabs.
Your document appears to use spaces to indent, but line 218 starts with tabs.
Your document appears to use spaces to indent, but line 219 starts with tabs.
Your document appears to use spaces to indent, but line 220 starts with tabs.
Your document appears to use spaces to indent, but line 221 starts with tabs.
Your document appears to use spaces to indent, but line 222 starts with tabs.
Your document appears to use spaces to indent, but line 223 starts with tabs.
Your document appears to use spaces to indent, but line 224 starts with tabs.
Your document appears to use spaces to indent, but line 225 starts with tabs.
Your document appears to use spaces to indent, but line 226 starts with tabs.
Your document appears to use spaces to indent, but line 227 starts with tabs.
Your document appears to use spaces to indent, but line 228 starts with tabs.
Your document appears to use spaces to indent, but line 229 starts with tabs.
Your document appears to use spaces to indent, but line 230 starts with tabs.
Your document appears to use spaces to indent, but line 231 starts with tabs.
Your document appears to use spaces to indent, but line 232 starts with tabs.
Your document appears to use spaces to indent, but line 233 starts with tabs.
Your document appears to use spaces to indent, but line 234 starts with tabs.
Your document appears to use spaces to indent, but line 235 starts with tabs.
Your document appears to use spaces to indent, but line 236 starts with tabs.
Your document appears to use spaces to indent, but line 237 starts with tabs.
Your document appears to use spaces to indent, but line 238 starts with tabs.
Your document appears to use spaces to indent, but line 239 starts with tabs.
Your document appears to use spaces to indent, but line 240 starts with tabs.
Your document appears to use spaces to indent, but line 241 starts with tabs.
Your document appears to use spaces to indent, but line 242 starts with tabs.
Your document appears to use spaces to indent, but line 243 starts with tabs.
Your document appears to use spaces to indent, but line 244 starts with tabs.
Your document appears to use spaces to indent, but line 245 starts with tabs.
Your document appears to use spaces to indent, but line 246 starts with tabs.
Your document appears to use spaces to indent, but line 247 starts with tabs.
Your document appears to use spaces to indent, but line 248 starts with tabs.
Your document appears to use spaces to indent, but line 249 starts with tabs.
Your document appears to use spaces to indent, but line 250 starts with tabs.
Your document appears to use spaces to indent, but line 251 starts with tabs.
Your document appears to use spaces to indent, but line 252 starts with tabs.
Your document appears to use spaces to indent, but line 253 starts with tabs.
Your document appears to use spaces to indent, but line 254 starts with tabs.
Your document appears to use spaces to indent, but line 255 starts with tabs.
Your document appears to use spaces to indent, but line 360 starts with tabs.
Your document appears to use spaces to indent, but line 511 starts with tabs.
Your document appears to use spaces to indent, but line 555 starts with tabs.
Your document appears to use spaces to indent, but line 849 starts with tabs.
Your document appears to use spaces to indent, but line 1139 starts with tabs.
Your document appears to use spaces to indent, but line 1140 starts with tabs.
Your document appears to use spaces to indent, but line 1644 starts with tabs.
Your document appears to use spaces to indent, but line 1645 starts with tabs.
Your document appears to use spaces to indent, but line 1646 starts with tabs.
Your document appears to use spaces to indent, but line 1647 starts with tabs.
Your document appears to use spaces to indent, but line 1648 starts with tabs.
Your document appears to use spaces to indent, but line 1649 starts with tabs.
Your document appears to use spaces to indent, but line 1695 starts with tabs.
Your document appears to use spaces to indent, but line 1696 starts with tabs.
Your document appears to use spaces to indent, but line 1710 starts with tabs.
Your document appears to use spaces to indent, but line 1714 starts with tabs.
Your document appears to use spaces to indent, but line 1715 starts with tabs.
Your document appears to use spaces to indent, but line 1717 starts with tabs.
Your document appears to use spaces to indent, but line 1718 starts with tabs.
Your document appears to use spaces to indent, but line 1751 starts with tabs.
Your document appears to use spaces to indent, but line 1752 starts with tabs.
Your document appears to use spaces to indent, but line 1753 starts with tabs.
Your document appears to use spaces to indent, but line 1754 starts with tabs.
Your document appears to use spaces to indent, but line 1755 starts with tabs.
Your document appears to use spaces to indent, but line 1756 starts with tabs.
Your document appears to use spaces to indent, but line 1757 starts with tabs.
Your document appears to use spaces to indent, but line 1767 starts with tabs.
Your document appears to use spaces to indent, but line 1768 starts with tabs.
Your document appears to use spaces to indent, but line 1850 starts with tabs.
Your document appears to use spaces to indent, but line 1851 starts with tabs.
Your document appears to use spaces to indent, but line 1855 starts with tabs.
Your document appears to use spaces to indent, but line 1856 starts with tabs.
Your document appears to use spaces to indent, but line 1858 starts with tabs.
Your document appears to use spaces to indent, but line 1860 starts with tabs.
Your document appears to use spaces to indent, but line 1865 starts with tabs.
Your document appears to use spaces to indent, but line 1866 starts with tabs.
Your document appears to use spaces to indent, but line 1867 starts with tabs.
Your document appears to use spaces to indent, but line 1868 starts with tabs.
Your document appears to use spaces to indent, but line 1928 starts with tabs.
Your document appears to use spaces to indent, but line 1934 starts with tabs.
Your document appears to use spaces to indent, but line 1940 starts with tabs.
Your document appears to use spaces to indent, but line 1946 starts with tabs.
Your document appears to use spaces to indent, but line 1975 starts with tabs.
Your document appears to use spaces to indent, but line 1976 starts with tabs.
Your document appears to use spaces to indent, but line 2045 starts with tabs.
Your document appears to use spaces to indent, but line 2046 starts with tabs.
Your document appears to use spaces to indent, but line 2048 starts with tabs.
Your document appears to use spaces to indent, but line 2049 starts with tabs.
Your document appears to use spaces to indent, but line 2050 starts with tabs.
Your document appears to use spaces to indent, but line 2051 starts with tabs.
Your document appears to use spaces to indent, but line 2062 starts with tabs.
Your document appears to use spaces to indent, but line 2075 starts with tabs.
Your document appears to use spaces to indent, but line 2076 starts with tabs.
Your document appears to use spaces to indent, but line 2077 starts with tabs.
Your document appears to use spaces to indent, but line 2078 starts with tabs.
Your document appears to use spaces to indent, but line 2080 starts with tabs.
Your document appears to use spaces to indent, but line 2081 starts with tabs.
Your document appears to use spaces to indent, but line 2122 starts with tabs.
Your document appears to use spaces to indent, but line 2123 starts with tabs.
Your document appears to use spaces to indent, but line 2132 starts with tabs.
Your document appears to use spaces to indent, but line 2133 starts with tabs.
Your document appears to use spaces to indent, but line 2134 starts with tabs.
Your document appears to use spaces to indent, but line 2135 starts with tabs.
Your document appears to use spaces to indent, but line 2136 starts with tabs.
Your document appears to use spaces to indent, but line 2137 starts with tabs.
Your document appears to use spaces to indent, but line 2138 starts with tabs.
Your document appears to use spaces to indent, but line 2161 starts with tabs.
Your document appears to use spaces to indent, but line 2162 starts with tabs.
Your document appears to use spaces to indent, but line 2163 starts with tabs.
Your document appears to use spaces to indent, but line 2164 starts with tabs.
Your document appears to use spaces to indent, but line 2165 starts with tabs.
Your document appears to use spaces to indent, but line 2166 starts with tabs.
Your document appears to use spaces to indent, but line 2167 starts with tabs.
Your document appears to use spaces to indent, but line 2415 starts with tabs.
Your document appears to use spaces to indent, but line 2427 starts with tabs.
Your document appears to use spaces to indent, but line 2428 starts with tabs.
Your document appears to use spaces to indent, but line 2429 starts with tabs.
Your document appears to use spaces to indent, but line 2430 starts with tabs.
Your document appears to use spaces to indent, but line 2431 starts with tabs.
Your document appears to use spaces to indent, but line 2432 starts with tabs.
Your document appears to use spaces to indent, but line 2433 starts with tabs.
Your document appears to use spaces to indent, but line 2436 starts with tabs.
Your document appears to use spaces to indent, but line 2446 starts with tabs.
Your document appears to use spaces to indent, but line 2447 starts with tabs.
Your document appears to use spaces to indent, but line 2448 starts with tabs.
Your document appears to use spaces to indent, but line 2449 starts with tabs.
Your document appears to use spaces to indent, but line 2450 starts with tabs.
Your document appears to use spaces to indent, but line 2451 starts with tabs.
Your document appears to use spaces to indent, but line 2452 starts with tabs.
Your document appears to use spaces to indent, but line 2453 starts with tabs.
Your document appears to use spaces to indent, but line 2456 starts with tabs.
Your document appears to use spaces to indent, but line 2463 starts with tabs.
Your document appears to use spaces to indent, but line 2464 starts with tabs.
Your document appears to use spaces to indent, but line 2465 starts with tabs.
Your document appears to use spaces to indent, but line 2466 starts with tabs.
Your document appears to use spaces to indent, but line 2467 starts with tabs.
Your document appears to use spaces to indent, but line 2468 starts with tabs.
Your document appears to use spaces to indent, but line 2469 starts with tabs.
Your document appears to use spaces to indent, but line 2470 starts with tabs.
Your document appears to use spaces to indent, but line 2471 starts with tabs.
Your document appears to use spaces to indent, but line 2472 starts with tabs.
Your document appears to use spaces to indent, but line 2473 starts with tabs.
Your document appears to use spaces to indent, but line 2474 starts with tabs.
Your document appears to use spaces to indent, but line 2475 starts with tabs.
Your document appears to use spaces to indent, but line 2476 starts with tabs.
Your document appears to use spaces to indent, but line 2477 starts with tabs.
Your document appears to use spaces to indent, but line 2478 starts with tabs.
Your document appears to use spaces to indent, but line 2479 starts with tabs.
Your document appears to use spaces to indent, but line 2480 starts with tabs.
Your document appears to use spaces to indent, but line 2481 starts with tabs.
Your document appears to use spaces to indent, but line 2482 starts with tabs.
Your document appears to use spaces to indent, but line 2483 starts with tabs.
Your document appears to use spaces to indent, but line 2484 starts with tabs.
Your document appears to use spaces to indent, but line 2485 starts with tabs.
Your document appears to use spaces to indent, but line 2486 starts with tabs.
Your document appears to use spaces to indent, but line 2487 starts with tabs.
Your document appears to use spaces to indent, but line 2489 starts with tabs.
Your document appears to use spaces to indent, but line 2490 starts with tabs.
Your document appears to use spaces to indent, but line 2495 starts with tabs.
Your document appears to use spaces to indent, but line 2498 starts with tabs.
Your document appears to use spaces to indent, but line 2501 starts with tabs.
Your document appears to use spaces to indent, but line 2505 starts with tabs.
Your document appears to use spaces to indent, but line 2506 starts with tabs.
Your document appears to use spaces to indent, but line 2521 starts with tabs.
Your document appears to use spaces to indent, but line 2533 starts with tabs.
Your document appears to use spaces to indent, but line 2544 starts with tabs.
Your document appears to use spaces to indent, but line 2566 starts with tabs.
Your document appears to use spaces to indent, but line 2567 starts with tabs.
Your document appears to use spaces to indent, but line 2568 starts with tabs.
Your document appears to use spaces to indent, but line 2569 starts with tabs.
Your document appears to use spaces to indent, but line 2571 starts with tabs.
Your document appears to use spaces to indent, but line 2572 starts with tabs.
Your document appears to use spaces to indent, but line 2576 starts with tabs.
Your document appears to use spaces to indent, but line 2577 starts with tabs.
Your document appears to use spaces to indent, but line 2697 starts with tabs.
Your document appears to use spaces to indent, but line 2698 starts with tabs.
Your document appears to use spaces to indent, but line 2699 starts with tabs.
Your document appears to use spaces to indent, but line 2700 starts with tabs.
Your document appears to use spaces to indent, but line 2702 starts with tabs.
Your document appears to use spaces to indent, but line 2703 starts with tabs.
Your document appears to use spaces to indent, but line 2704 starts with tabs.
Your document appears to use spaces to indent, but line 2706 starts with tabs.
Your document appears to use spaces to indent, but line 2707 starts with tabs.
Your document appears to use spaces to indent, but line 2731 starts with tabs.
Your document appears to use spaces to indent, but line 2732 starts with tabs.
Your document appears to use spaces to indent, but line 2733 starts with tabs.
Your document appears to use spaces to indent, but line 2734 starts with tabs.
Your document appears to use spaces to indent, but line 2735 starts with tabs.
Your document appears to use spaces to indent, but line 2736 starts with tabs.
Your document appears to use spaces to indent, but line 2737 starts with tabs.
Your document appears to use spaces to indent, but line 2739 starts with tabs.
Your document appears to use spaces to indent, but line 2752 starts with tabs.
Your document appears to use spaces to indent, but line 2753 starts with tabs.
Your document appears to use spaces to indent, but line 2754 starts with tabs.
Your document appears to use spaces to indent, but line 2755 starts with tabs.
Your document appears to use spaces to indent, but line 2758 starts with tabs.
Your document appears to use spaces to indent, but line 2759 starts with tabs.
Your document appears to use spaces to indent, but line 2832 starts with tabs.
Your document appears to use spaces to indent, but line 2833 starts with tabs.
Your document appears to use spaces to indent, but line 2834 starts with tabs.
Your document appears to use spaces to indent, but line 2835 starts with tabs.
Your document appears to use spaces to indent, but line 2836 starts with tabs.
Your document appears to use spaces to indent, but line 2837 starts with tabs.
Your document appears to use spaces to indent, but line 2838 starts with tabs.
Your document appears to use spaces to indent, but line 2839 starts with tabs.
Your document appears to use spaces to indent, but line 2840 starts with tabs.
WARNING: The heading 'Annex' needs a manually-specified ID.
WARNING: At least one &lt;img> doesn't have its size set (&lt;img bs-line-number="325" src="images/Hypothetical%20IAMF%20Architecture.png" style="width:100%; height:auto;">), but given the type of input document, Bikeshed can't figure out what the size should be.
Either set 'width'/'height' manually, or opt out of auto-detection by setting the 'no-autosize' attribute.
WARNING: Multiple elements have the same ID 'descriptors'.
Deduping, but this ID may not be stable across revisions.
WARNING: Multiple elements have the same ID 'loudness_info'.
Deduping, but this ID may not be stable across revisions.
FATAL ERROR: Multiple local 'dfn' &lt;dfn>s have the same linking text 'loudness_info()'.
 ✘  Did not generate, due to fatal errors
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20AOMediaCodec/iamf%23645.)._
</details>
