### PR TITLE
loudness_info() -> loudness

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1125,12 +1125,12 @@ class mix_presentation_obu() {
 
 <dfn noexport>loudness_layout</dfn> identifies the layout that was used to measure the loudness information provided in this sub-mix.
 
-<dfn noexport>loudness_info()</dfn> provides the loudness information which was measured on [=loudness_layout=] for the [=Rendered Mix Presentation=] by this sub-mix.
+<dfn noexport>loudness</dfn> provides the loudness information which was measured on [=loudness_layout=] for the [=Rendered Mix Presentation=] by this sub-mix.
 
 The layout specified in [=loudness_layout=] SHOULD NOT be higher than the highest layout among layouts provided by the [=Audio Element=]s except zero-order Ambisonics or Mono. In other words, rendering from an [=Audio Element=] with the highest layout (except zero-order Ambisonics or Mono) to the [=loudness_layout=] SHOULD NOT require an up-mix.
 - [=loudness_layout=] for zero-order Ambisonics or Mono SHOULD NOT be higher than Stereo. Zero-order Ambisonics or Mono MAY be rendered to Stereo.
 
-Each sub-mix SHALL include [=loudness_info()=] for Stereo (i.e., [=loudness_layout=] = [=Loudspeaker configuration for Sound System A (0+2+0)=]).
+Each sub-mix SHALL include [=loudness=] for Stereo (i.e., [=loudness_layout=] = [=Loudspeaker configuration for Sound System A (0+2+0)=]).
 - If a sub-mix's [=Rendered Mix Presentation=] is Mono, its [=loudness=] for [=loudness_layout=] = Stereo SHOULD be measured on the Stereo signal generated using the equations, L = 0.707 * Mono and R = 0.707 * Mono. 
 
 If one sub-mix of [=Mix Presentation OBU=] includes only one single scalable channel audio, then it SHALL comply with the following.


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jul 18, 2023, 12:02 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2FAOMediaCodec%2Fiamf%2F85c5fd462b4539e39a44479478862183957da98c%2Findex.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 2.
Your document appears to use tabs to indent, but line 411 starts with spaces.
Your document appears to use tabs to indent, but line 413 starts with spaces.
Your document appears to use tabs to indent, but line 414 starts with spaces.
Your document appears to use tabs to indent, but line 415 starts with spaces.
Your document appears to use tabs to indent, but line 416 starts with spaces.
Your document appears to use tabs to indent, but line 417 starts with spaces.
Your document appears to use tabs to indent, but line 418 starts with spaces.
Your document appears to use tabs to indent, but line 419 starts with spaces.
Your document appears to use tabs to indent, but line 420 starts with spaces.
Your document appears to use tabs to indent, but line 421 starts with spaces.
Your document appears to use tabs to indent, but line 422 starts with spaces.
Your document appears to use tabs to indent, but line 423 starts with spaces.
Your document appears to use tabs to indent, but line 424 starts with spaces.
Your document appears to use tabs to indent, but line 425 starts with spaces.
Your document appears to use tabs to indent, but line 426 starts with spaces.
Your document appears to use tabs to indent, but line 427 starts with spaces.
Your document appears to use tabs to indent, but line 428 starts with spaces.
Your document appears to use tabs to indent, but line 429 starts with spaces.
Your document appears to use tabs to indent, but line 430 starts with spaces.
Your document appears to use tabs to indent, but line 445 starts with spaces.
Your document appears to use tabs to indent, but line 446 starts with spaces.
Your document appears to use tabs to indent, but line 447 starts with spaces.
Your document appears to use tabs to indent, but line 448 starts with spaces.
Your document appears to use tabs to indent, but line 449 starts with spaces.
Your document appears to use tabs to indent, but line 451 starts with spaces.
Your document appears to use tabs to indent, but line 452 starts with spaces.
Your document appears to use tabs to indent, but line 453 starts with spaces.
Your document appears to use tabs to indent, but line 454 starts with spaces.
Your document appears to use tabs to indent, but line 455 starts with spaces.
Your document appears to use tabs to indent, but line 456 starts with spaces.
Your document appears to use tabs to indent, but line 457 starts with spaces.
Your document appears to use tabs to indent, but line 458 starts with spaces.
Your document appears to use tabs to indent, but line 468 starts with spaces.
Your document appears to use tabs to indent, but line 469 starts with spaces.
Your document appears to use tabs to indent, but line 470 starts with spaces.
Your document appears to use tabs to indent, but line 471 starts with spaces.
Your document appears to use tabs to indent, but line 472 starts with spaces.
Your document appears to use tabs to indent, but line 473 starts with spaces.
Your document appears to use tabs to indent, but line 474 starts with spaces.
Your document appears to use tabs to indent, but line 475 starts with spaces.
Your document appears to use tabs to indent, but line 476 starts with spaces.
Your document appears to use tabs to indent, but line 546 starts with spaces.
Your document appears to use tabs to indent, but line 547 starts with spaces.
Your document appears to use tabs to indent, but line 548 starts with spaces.
Your document appears to use tabs to indent, but line 577 starts with spaces.
Your document appears to use tabs to indent, but line 578 starts with spaces.
Your document appears to use tabs to indent, but line 582 starts with spaces.
Your document appears to use tabs to indent, but line 583 starts with spaces.
Your document appears to use tabs to indent, but line 584 starts with spaces.
Your document appears to use tabs to indent, but line 585 starts with spaces.
Your document appears to use tabs to indent, but line 621 starts with spaces.
Your document appears to use tabs to indent, but line 622 starts with spaces.
Your document appears to use tabs to indent, but line 623 starts with spaces.
Your document appears to use tabs to indent, but line 624 starts with spaces.
Your document appears to use tabs to indent, but line 625 starts with spaces.
Your document appears to use tabs to indent, but line 627 starts with spaces.
Your document appears to use tabs to indent, but line 628 starts with spaces.
Your document appears to use tabs to indent, but line 629 starts with spaces.
Your document appears to use tabs to indent, but line 630 starts with spaces.
Your document appears to use tabs to indent, but line 631 starts with spaces.
Your document appears to use tabs to indent, but line 632 starts with spaces.
Your document appears to use tabs to indent, but line 633 starts with spaces.
Your document appears to use tabs to indent, but line 634 starts with spaces.
Your document appears to use tabs to indent, but line 635 starts with spaces.
Your document appears to use tabs to indent, but line 636 starts with spaces.
Your document appears to use tabs to indent, but line 637 starts with spaces.
Your document appears to use tabs to indent, but line 638 starts with spaces.
Your document appears to use tabs to indent, but line 639 starts with spaces.
Your document appears to use tabs to indent, but line 640 starts with spaces.
Your document appears to use tabs to indent, but line 641 starts with spaces.
Your document appears to use tabs to indent, but line 642 starts with spaces.
Your document appears to use tabs to indent, but line 643 starts with spaces.
Your document appears to use tabs to indent, but line 644 starts with spaces.
Your document appears to use tabs to indent, but line 645 starts with spaces.
Your document appears to use tabs to indent, but line 647 starts with spaces.
Your document appears to use tabs to indent, but line 648 starts with spaces.
Your document appears to use tabs to indent, but line 649 starts with spaces.
Your document appears to use tabs to indent, but line 650 starts with spaces.
Your document appears to use tabs to indent, but line 651 starts with spaces.
Your document appears to use tabs to indent, but line 652 starts with spaces.
Your document appears to use tabs to indent, but line 653 starts with spaces.
Your document appears to use tabs to indent, but line 654 starts with spaces.
Your document appears to use tabs to indent, but line 660 starts with spaces.
Your document appears to use tabs to indent, but line 666 starts with spaces.
Your document appears to use tabs to indent, but line 667 starts with spaces.
Your document appears to use tabs to indent, but line 685 starts with spaces.
Your document appears to use tabs to indent, but line 686 starts with spaces.
Your document appears to use tabs to indent, but line 687 starts with spaces.
Your document appears to use tabs to indent, but line 704 starts with spaces.
Your document appears to use tabs to indent, but line 705 starts with spaces.
Your document appears to use tabs to indent, but line 706 starts with spaces.
Your document appears to use tabs to indent, but line 707 starts with spaces.
Your document appears to use tabs to indent, but line 725 starts with spaces.
Your document appears to use tabs to indent, but line 728 starts with spaces.
Your document appears to use tabs to indent, but line 731 starts with spaces.
Your document appears to use tabs to indent, but line 734 starts with spaces.
Your document appears to use tabs to indent, but line 788 starts with spaces.
Your document appears to use tabs to indent, but line 789 starts with spaces.
Your document appears to use tabs to indent, but line 790 starts with spaces.
Your document appears to use tabs to indent, but line 791 starts with spaces.
Your document appears to use tabs to indent, but line 792 starts with spaces.
Your document appears to use tabs to indent, but line 793 starts with spaces.
Your document appears to use tabs to indent, but line 794 starts with spaces.
Your document appears to use tabs to indent, but line 795 starts with spaces.
Your document appears to use tabs to indent, but line 796 starts with spaces.
Your document appears to use tabs to indent, but line 797 starts with spaces.
Your document appears to use tabs to indent, but line 798 starts with spaces.
Your document appears to use tabs to indent, but line 799 starts with spaces.
Your document appears to use tabs to indent, but line 800 starts with spaces.
Your document appears to use tabs to indent, but line 813 starts with spaces.
Your document appears to use tabs to indent, but line 814 starts with spaces.
Your document appears to use tabs to indent, but line 815 starts with spaces.
Your document appears to use tabs to indent, but line 816 starts with spaces.
Your document appears to use tabs to indent, but line 817 starts with spaces.
Your document appears to use tabs to indent, but line 818 starts with spaces.
Your document appears to use tabs to indent, but line 819 starts with spaces.
Your document appears to use tabs to indent, but line 820 starts with spaces.
Your document appears to use tabs to indent, but line 821 starts with spaces.
Your document appears to use tabs to indent, but line 822 starts with spaces.
Your document appears to use tabs to indent, but line 823 starts with spaces.
Your document appears to use tabs to indent, but line 824 starts with spaces.
Your document appears to use tabs to indent, but line 825 starts with spaces.
Your document appears to use tabs to indent, but line 826 starts with spaces.
Your document appears to use tabs to indent, but line 866 starts with spaces.
Your document appears to use tabs to indent, but line 867 starts with spaces.
Your document appears to use tabs to indent, but line 868 starts with spaces.
Your document appears to use tabs to indent, but line 869 starts with spaces.
Your document appears to use tabs to indent, but line 870 starts with spaces.
Your document appears to use tabs to indent, but line 874 starts with spaces.
Your document appears to use tabs to indent, but line 875 starts with spaces.
Your document appears to use tabs to indent, but line 876 starts with spaces.
Your document appears to use tabs to indent, but line 877 starts with spaces.
Your document appears to use tabs to indent, but line 878 starts with spaces.
Your document appears to use tabs to indent, but line 879 starts with spaces.
Your document appears to use tabs to indent, but line 880 starts with spaces.
Your document appears to use tabs to indent, but line 881 starts with spaces.
Your document appears to use tabs to indent, but line 882 starts with spaces.
Your document appears to use tabs to indent, but line 883 starts with spaces.
Your document appears to use tabs to indent, but line 884 starts with spaces.
Your document appears to use tabs to indent, but line 927 starts with spaces.
Your document appears to use tabs to indent, but line 928 starts with spaces.
Your document appears to use tabs to indent, but line 929 starts with spaces.
Your document appears to use tabs to indent, but line 930 starts with spaces.
Your document appears to use tabs to indent, but line 931 starts with spaces.
Your document appears to use tabs to indent, but line 932 starts with spaces.
Your document appears to use tabs to indent, but line 933 starts with spaces.
Your document appears to use tabs to indent, but line 934 starts with spaces.
Your document appears to use tabs to indent, but line 935 starts with spaces.
Your document appears to use tabs to indent, but line 936 starts with spaces.
Your document appears to use tabs to indent, but line 937 starts with spaces.
Your document appears to use tabs to indent, but line 984 starts with spaces.
Your document appears to use tabs to indent, but line 985 starts with spaces.
Your document appears to use tabs to indent, but line 986 starts with spaces.
Your document appears to use tabs to indent, but line 987 starts with spaces.
Your document appears to use tabs to indent, but line 988 starts with spaces.
Your document appears to use tabs to indent, but line 989 starts with spaces.
Your document appears to use tabs to indent, but line 1004 starts with spaces.
Your document appears to use tabs to indent, but line 1005 starts with spaces.
Your document appears to use tabs to indent, but line 1006 starts with spaces.
Your document appears to use tabs to indent, but line 1007 starts with spaces.
Your document appears to use tabs to indent, but line 1008 starts with spaces.
Your document appears to use tabs to indent, but line 1009 starts with spaces.
Your document appears to use tabs to indent, but line 1013 starts with spaces.
Your document appears to use tabs to indent, but line 1014 starts with spaces.
Your document appears to use tabs to indent, but line 1015 starts with spaces.
Your document appears to use tabs to indent, but line 1019 starts with spaces.
Your document appears to use tabs to indent, but line 1020 starts with spaces.
Your document appears to use tabs to indent, but line 1021 starts with spaces.
Your document appears to use tabs to indent, but line 1022 starts with spaces.
Your document appears to use tabs to indent, but line 1032 starts with spaces.
Your document appears to use tabs to indent, but line 1033 starts with spaces.
Your document appears to use tabs to indent, but line 1068 starts with spaces.
Your document appears to use tabs to indent, but line 1069 starts with spaces.
Your document appears to use tabs to indent, but line 1070 starts with spaces.
Your document appears to use tabs to indent, but line 1071 starts with spaces.
Your document appears to use tabs to indent, but line 1072 starts with spaces.
Your document appears to use tabs to indent, but line 1073 starts with spaces.
Your document appears to use tabs to indent, but line 1074 starts with spaces.
Your document appears to use tabs to indent, but line 1075 starts with spaces.
Your document appears to use tabs to indent, but line 1077 starts with spaces.
Your document appears to use tabs to indent, but line 1078 starts with spaces.
Your document appears to use tabs to indent, but line 1079 starts with spaces.
Your document appears to use tabs to indent, but line 1080 starts with spaces.
Your document appears to use tabs to indent, but line 1081 starts with spaces.
Your document appears to use tabs to indent, but line 1082 starts with spaces.
Your document appears to use tabs to indent, but line 1083 starts with spaces.
Your document appears to use tabs to indent, but line 1084 starts with spaces.
Your document appears to use tabs to indent, but line 1085 starts with spaces.
Your document appears to use tabs to indent, but line 1086 starts with spaces.
Your document appears to use tabs to indent, but line 1087 starts with spaces.
Your document appears to use tabs to indent, but line 1088 starts with spaces.
Your document appears to use tabs to indent, but line 1089 starts with spaces.
Your document appears to use tabs to indent, but line 1090 starts with spaces.
Your document appears to use tabs to indent, but line 1091 starts with spaces.
Your document appears to use tabs to indent, but line 1092 starts with spaces.
Your document appears to use tabs to indent, but line 1093 starts with spaces.
Your document appears to use tabs to indent, but line 1094 starts with spaces.
Your document appears to use tabs to indent, but line 1095 starts with spaces.
Your document appears to use tabs to indent, but line 1141 starts with spaces.
Your document appears to use tabs to indent, but line 1147 starts with spaces.
Your document appears to use tabs to indent, but line 1161 starts with spaces.
Your document appears to use tabs to indent, but line 1177 starts with spaces.
Your document appears to use tabs to indent, but line 1178 starts with spaces.
Your document appears to use tabs to indent, but line 1179 starts with spaces.
Your document appears to use tabs to indent, but line 1180 starts with spaces.
Your document appears to use tabs to indent, but line 1209 starts with spaces.
Your document appears to use tabs to indent, but line 1215 starts with spaces.
Your document appears to use tabs to indent, but line 1234 starts with spaces.
Your document appears to use tabs to indent, but line 1251 starts with spaces.
Your document appears to use tabs to indent, but line 1252 starts with spaces.
Your document appears to use tabs to indent, but line 1253 starts with spaces.
Your document appears to use tabs to indent, but line 1254 starts with spaces.
Your document appears to use tabs to indent, but line 1255 starts with spaces.
Your document appears to use tabs to indent, but line 1256 starts with spaces.
Your document appears to use tabs to indent, but line 1257 starts with spaces.
Your document appears to use tabs to indent, but line 1258 starts with spaces.
Your document appears to use tabs to indent, but line 1259 starts with spaces.
Your document appears to use tabs to indent, but line 1269 starts with spaces.
Your document appears to use tabs to indent, but line 1270 starts with spaces.
Your document appears to use tabs to indent, but line 1271 starts with spaces.
Your document appears to use tabs to indent, but line 1281 starts with spaces.
Your document appears to use tabs to indent, but line 1282 starts with spaces.
Your document appears to use tabs to indent, but line 1283 starts with spaces.
Your document appears to use tabs to indent, but line 1284 starts with spaces.
Your document appears to use tabs to indent, but line 1285 starts with spaces.
Your document appears to use tabs to indent, but line 1286 starts with spaces.
Your document appears to use tabs to indent, but line 1287 starts with spaces.
Your document appears to use tabs to indent, but line 1288 starts with spaces.
Your document appears to use tabs to indent, but line 1289 starts with spaces.
Your document appears to use tabs to indent, but line 1290 starts with spaces.
Your document appears to use tabs to indent, but line 1291 starts with spaces.
Your document appears to use tabs to indent, but line 1292 starts with spaces.
Your document appears to use tabs to indent, but line 1293 starts with spaces.
Your document appears to use tabs to indent, but line 1294 starts with spaces.
Your document appears to use tabs to indent, but line 1308 starts with spaces.
Your document appears to use tabs to indent, but line 1309 starts with spaces.
Your document appears to use tabs to indent, but line 1310 starts with spaces.
Your document appears to use tabs to indent, but line 1312 starts with spaces.
Your document appears to use tabs to indent, but line 1313 starts with spaces.
Your document appears to use tabs to indent, but line 1314 starts with spaces.
Your document appears to use tabs to indent, but line 1316 starts with spaces.
Your document appears to use tabs to indent, but line 1317 starts with spaces.
Your document appears to use tabs to indent, but line 1318 starts with spaces.
Your document appears to use tabs to indent, but line 1319 starts with spaces.
Your document appears to use tabs to indent, but line 1320 starts with spaces.
Your document appears to use tabs to indent, but line 1321 starts with spaces.
Your document appears to use tabs to indent, but line 1322 starts with spaces.
Your document appears to use tabs to indent, but line 1323 starts with spaces.
Your document appears to use tabs to indent, but line 1324 starts with spaces.
Your document appears to use tabs to indent, but line 1325 starts with spaces.
Your document appears to use tabs to indent, but line 1326 starts with spaces.
Your document appears to use tabs to indent, but line 1327 starts with spaces.
Your document appears to use tabs to indent, but line 1336 starts with spaces.
Your document appears to use tabs to indent, but line 1337 starts with spaces.
Your document appears to use tabs to indent, but line 1338 starts with spaces.
Your document appears to use tabs to indent, but line 1339 starts with spaces.
Your document appears to use tabs to indent, but line 1353 starts with spaces.
Your document appears to use tabs to indent, but line 1354 starts with spaces.
Your document appears to use tabs to indent, but line 1355 starts with spaces.
Your document appears to use tabs to indent, but line 1356 starts with spaces.
Your document appears to use tabs to indent, but line 1379 starts with spaces.
Your document appears to use tabs to indent, but line 1380 starts with spaces.
Your document appears to use tabs to indent, but line 1381 starts with spaces.
Your document appears to use tabs to indent, but line 1382 starts with spaces.
Your document appears to use tabs to indent, but line 1383 starts with spaces.
Your document appears to use tabs to indent, but line 1384 starts with spaces.
Your document appears to use tabs to indent, but line 1385 starts with spaces.
Your document appears to use tabs to indent, but line 1386 starts with spaces.
Your document appears to use tabs to indent, but line 1387 starts with spaces.
Your document appears to use tabs to indent, but line 1388 starts with spaces.
Your document appears to use tabs to indent, but line 1389 starts with spaces.
Your document appears to use tabs to indent, but line 1390 starts with spaces.
Your document appears to use tabs to indent, but line 1391 starts with spaces.
Your document appears to use tabs to indent, but line 1393 starts with spaces.
Your document appears to use tabs to indent, but line 1394 starts with spaces.
Your document appears to use tabs to indent, but line 1395 starts with spaces.
Your document appears to use tabs to indent, but line 1396 starts with spaces.
Your document appears to use tabs to indent, but line 1397 starts with spaces.
Your document appears to use tabs to indent, but line 1398 starts with spaces.
Your document appears to use tabs to indent, but line 1400 starts with spaces.
Your document appears to use tabs to indent, but line 1401 starts with spaces.
Your document appears to use tabs to indent, but line 1402 starts with spaces.
Your document appears to use tabs to indent, but line 1403 starts with spaces.
Your document appears to use tabs to indent, but line 1404 starts with spaces.
Your document appears to use tabs to indent, but line 1405 starts with spaces.
Your document appears to use tabs to indent, but line 1406 starts with spaces.
Your document appears to use tabs to indent, but line 1407 starts with spaces.
Your document appears to use tabs to indent, but line 1408 starts with spaces.
Your document appears to use tabs to indent, but line 1409 starts with spaces.
Your document appears to use tabs to indent, but line 1410 starts with spaces.
Your document appears to use tabs to indent, but line 1411 starts with spaces.
Your document appears to use tabs to indent, but line 1412 starts with spaces.
Your document appears to use tabs to indent, but line 1413 starts with spaces.
Your document appears to use tabs to indent, but line 1449 starts with spaces.
Your document appears to use tabs to indent, but line 1450 starts with spaces.
Your document appears to use tabs to indent, but line 1460 starts with spaces.
Your document appears to use tabs to indent, but line 1461 starts with spaces.
Your document appears to use tabs to indent, but line 1462 starts with spaces.
Your document appears to use tabs to indent, but line 1470 starts with spaces.
Your document appears to use tabs to indent, but line 1471 starts with spaces.
Your document appears to use tabs to indent, but line 1472 starts with spaces.
Your document appears to use tabs to indent, but line 1473 starts with spaces.
Your document appears to use tabs to indent, but line 1474 starts with spaces.
Your document appears to use tabs to indent, but line 1475 starts with spaces.
Your document appears to use tabs to indent, but line 1476 starts with spaces.
Your document appears to use tabs to indent, but line 1477 starts with spaces.
Your document appears to use tabs to indent, but line 1478 starts with spaces.
Your document appears to use tabs to indent, but line 1479 starts with spaces.
Your document appears to use tabs to indent, but line 1480 starts with spaces.
Your document appears to use tabs to indent, but line 1481 starts with spaces.
Your document appears to use tabs to indent, but line 1482 starts with spaces.
Your document appears to use tabs to indent, but line 1504 starts with spaces.
Your document appears to use tabs to indent, but line 1505 starts with spaces.
Your document appears to use tabs to indent, but line 1537 starts with spaces.
Your document appears to use tabs to indent, but line 1538 starts with spaces.
Your document appears to use tabs to indent, but line 1539 starts with spaces.
Your document appears to use tabs to indent, but line 1540 starts with spaces.
Your document appears to use tabs to indent, but line 1541 starts with spaces.
Your document appears to use tabs to indent, but line 1542 starts with spaces.
Your document appears to use tabs to indent, but line 1543 starts with spaces.
Your document appears to use tabs to indent, but line 1544 starts with spaces.
Your document appears to use tabs to indent, but line 1545 starts with spaces.
Your document appears to use tabs to indent, but line 1556 starts with spaces.
Your document appears to use tabs to indent, but line 1557 starts with spaces.
Your document appears to use tabs to indent, but line 1574 starts with spaces.
Your document appears to use tabs to indent, but line 1575 starts with spaces.
Your document appears to use tabs to indent, but line 1576 starts with spaces.
Your document appears to use tabs to indent, but line 1577 starts with spaces.
Your document appears to use tabs to indent, but line 1683 starts with spaces.
Your document appears to use tabs to indent, but line 1684 starts with spaces.
Your document appears to use tabs to indent, but line 1685 starts with spaces.
Your document appears to use tabs to indent, but line 1877 starts with spaces.
Your document appears to use tabs to indent, but line 1899 starts with spaces.
Your document appears to use tabs to indent, but line 1961 starts with spaces.
Your document appears to use tabs to indent, but line 1962 starts with spaces.
Your document appears to use tabs to indent, but line 2079 starts with spaces.
Your document appears to use tabs to indent, but line 2080 starts with spaces.
Your document appears to use tabs to indent, but line 2081 starts with spaces.
Your document appears to use tabs to indent, but line 2082 starts with spaces.
Your document appears to use tabs to indent, but line 2083 starts with spaces.
Your document appears to use tabs to indent, but line 2084 starts with spaces.
Your document appears to use tabs to indent, but line 2085 starts with spaces.
Your document appears to use tabs to indent, but line 2086 starts with spaces.
Your document appears to use tabs to indent, but line 2087 starts with spaces.
Your document appears to use tabs to indent, but line 2088 starts with spaces.
Your document appears to use tabs to indent, but line 2089 starts with spaces.
Your document appears to use tabs to indent, but line 2090 starts with spaces.
Your document appears to use tabs to indent, but line 2166 starts with spaces.
Your document appears to use tabs to indent, but line 2169 starts with spaces.
Your document appears to use tabs to indent, but line 2172 starts with spaces.
Your document appears to use tabs to indent, but line 2175 starts with spaces.
Your document appears to use tabs to indent, but line 2178 starts with spaces.
Your document appears to use tabs to indent, but line 2529 starts with spaces.
Your document appears to use tabs to indent, but line 2598 starts with spaces.
Your document appears to use tabs to indent, but line 2599 starts with spaces.
Your document appears to use tabs to indent, but line 2600 starts with spaces.
Your document appears to use tabs to indent, but line 2602 starts with spaces.
Your document appears to use tabs to indent, but line 2603 starts with spaces.
Your document appears to use tabs to indent, but line 2604 starts with spaces.
Your document appears to use tabs to indent, but line 2607 starts with spaces.
Your document appears to use tabs to indent, but line 2609 starts with spaces.
Your document appears to use tabs to indent, but line 2614 starts with spaces.
Your document appears to use tabs to indent, but line 2617 starts with spaces.
Your document appears to use tabs to indent, but line 2620 starts with spaces.
Your document appears to use tabs to indent, but line 2623 starts with spaces.
Your document appears to use tabs to indent, but line 2626 starts with spaces.
Your document appears to use tabs to indent, but line 2629 starts with spaces.
Your document appears to use tabs to indent, but line 2632 starts with spaces.
Your document appears to use tabs to indent, but line 2647 starts with spaces.
Your document appears to use tabs to indent, but line 2651 starts with spaces.
Your document appears to use tabs to indent, but line 2656 starts with spaces.
Your document appears to use tabs to indent, but line 2658 starts with spaces.
Your document appears to use tabs to indent, but line 2839 starts with spaces.
WARNING: The heading 'Annex' needs a manually-specified ID.
WARNING: At least one &lt;img> doesn't have its size set (&lt;img bs-line-number="325" src="images/Hypothetical%20IAMF%20Architecture.png" style="width:100%; height:auto;">), but given the type of input document, Bikeshed can't figure out what the size should be.
Either set 'width'/'height' manually, or opt out of auto-detection by setting the 'no-autosize' attribute.
WARNING: Multiple elements have the same ID 'descriptors'.
Deduping, but this ID may not be stable across revisions.
WARNING: Multiple elements have the same ID 'loudness_info'.
Deduping, but this ID may not be stable across revisions.
FATAL ERROR: Multiple local 'dfn' &lt;dfn>s have the same linking text 'loudness_info()'.
 ✘  Did not generate, due to fatal errors
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20AOMediaCodec/iamf%23646.)._
</details>
