### PR TITLE
Fix missing layout_type and add link to layout syntax definition

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1140,15 +1140,15 @@ class MixPresentationOBU() {
 
 <dfn noexport>num_layouts</dfn> specifies the number of layouts for this sub-mix on which the [=loudness=] information was measured.
 
-<dfn noexport>loudness_layout</dfn> identifies the layout that was used to measure the [=loudness=] information provided in this sub-mix.
+<dfn noexport>loudness_layout</dfn> provides information about the [[#syntax-layout|layout]] that was used to measure the [=loudness=] information provided in this sub-mix.
 
 <dfn noexport>loudness</dfn> provides the loudness information which was measured on [=loudness_layout=] for the [=Rendered Mix Presentation=] by this sub-mix.
 
 The layout specified in [=loudness_layout=] SHOULD NOT be higher than the highest layout among layouts provided by the [=Audio Element=]s except zero-order Ambisonics or Mono. In other words, rendering from an [=Audio Element=] with the highest layout (except zero-order Ambisonics or Mono) to the [=loudness_layout=] SHOULD NOT require an up-mix.
-- [=loudness_layout=] for zero-order Ambisonics or Mono SHOULD NOT be higher than Stereo. Zero-order Ambisonics or Mono MAY be rendered to Stereo.
+- The layout specified in [=loudness_layout=] for zero-order Ambisonics or Mono SHOULD NOT be higher than Stereo. Zero-order Ambisonics or Mono MAY be rendered to Stereo.
 
-Each sub-mix SHALL include [=loudness=] for Stereo (i.e., [=loudness_layout=] = [=Loudspeaker configuration for Sound System A (0+2+0)=]).
-- If a sub-mix's [=Rendered Mix Presentation=] is Mono, its [=loudness=] for [=loudness_layout=] = Stereo SHOULD be measured on the Stereo signal generated using the equations, L = 0.707 * Mono and R = 0.707 * Mono. 
+Each sub-mix SHALL include [=loudness=] for Stereo (i.e., a [=loudness_layout=] with the [=sound_system=] field = [=Loudspeaker configuration for Sound System A (0+2+0)=]).
+- If a sub-mix's [=Rendered Mix Presentation=] is Mono, its [=loudness=] for Stereo SHOULD be measured on the Stereo signal generated using the equations, L = 0.707 * Mono and R = 0.707 * Mono.
 
 If one sub-mix of [=Mix Presentation OBU=] includes only one single scalable channel audio, then it SHALL comply with the following.
 - [=num_layouts=] SHALL be greater than or equal to [=num_layers=] specified in its [=scalable_channel_layout_config=], except in the following cases:
@@ -1310,7 +1310,7 @@ layout_type : Layout type
  - 12: It indicates Mono
  - 13 ~ 15: Reserved
 
-When a value for [=layout_type=] or [=sound_system=] is not supported, parsers compliant with this version of the specification SHOULD ignore this Layout() and the following [=LoudnessInfo()=].
+When a value for [=layout_type=] or [=sound_system=] is not supported, parsers compliant with this version of the specification SHOULD ignore this Layout() and any associated [=LoudnessInfo()=].
 
 ### Loudness Info Syntax and Semantics ### {#obu-mixpresentation-loudness}
 
@@ -2176,7 +2176,7 @@ When an [=IA Sequence=] contains multiple [=Mix Presentation=]s, the IA parser S
 2. If there is more than one valid mix remaining, the IA parser SHOULD select an appropriate mix for rendering, in the following order.
 	1. If the playback device is headphones:
 		1. Select the mix with [=mix_presentation_obu/audio_element_id=] whose [=loudspeaker_layout=] is BINAURAL.
-		2. If there is no such mix, select the mix with [=loudness_layout=] = BINAURAL.
+		2. If there is no such mix, select the mix with the [=layout_type=] field in [=loudness_layout=] = BINAURAL.
 		3. If there is no such mix, select the mix with the highest available [=loudness_layout=].
 	2. If the playback layout is loudspeakers:
 		1. If there is a mix with a [=loudness_layout=] that matches the playback loudspeaker layout, it SHOULD be selected. If there is more than one matching mix, the first one SHOULD be selected.


### PR DESCRIPTION
Fixes #697


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/felicialim/iamf/pull/725.html" title="Last updated on Aug 25, 2023, 2:05 AM UTC (52da5c5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/725/77748c8...felicialim:52da5c5.html" title="Last updated on Aug 25, 2023, 2:05 AM UTC (52da5c5)">Diff</a>