### PR TITLE
Drop definitions for basic arithmetic operators

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2803,18 +2803,6 @@ class Bar {
 
 <table class="def">
 <tr>
-  <td>\(+\)</td><td>Addition.</td>
-</tr>
-<tr>
-  <td>\(-\)</td><td>Subtraction.</td>
-</tr>
-<tr>
-  <td>\(\times\)</td><td>Multiplication.</td>
-</tr>
-<tr>
-  <td>\(\frac{\cdot}{\cdot}\)</td><td>Floating point (arithmetic) division.</td>
-</tr>
-<tr>
   <td>\(\left\lfloor{x}\right\rfloor \)</td><td>The largest integer that is smaller than or equal to \(x\).</td>
 </tr>
 <tr>


### PR DESCRIPTION
Fixes #688


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/felicialim/iamf/pull/735.html" title="Last updated on Aug 25, 2023, 9:32 PM UTC (6b9fb06)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/735/77748c8...felicialim:6b9fb06.html" title="Last updated on Aug 25, 2023, 9:32 PM UTC (6b9fb06)">Diff</a>