### PR TITLE
Fix #766, Duplicate values of audio_element_ids in one MixPresentatio…

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1176,7 +1176,7 @@ class MixPresentationOBU() {
 
 <dfn noexport>num_sub_mixes</dfn> specifies the number of sub-mixes. It SHALL NOT be set to 0. 
 
-<dfn noexport>num_audio_elements</dfn> specifies the number of [=Audio Element=]s that are used in this [=Mix Presentation=] to generate the final output audio signal for playback. It SHALL NOT be set to 0. 
+<dfn noexport>num_audio_elements</dfn> specifies the number of [=Audio Element=]s that are used in each sub-mix of this [=Mix Presentation=] to generate the final output audio signal for playback. It SHALL NOT be set to 0. There SHALL be no duplicate values of [=audio_element_obu/audio_element_id=] within one [=Mix Presentation=].
 
 <dfn noexport for="mix_presentation_obu">audio_element_id</dfn> indicates the identifier for an [=Audio Element=] which this [=Mix Presentation=] refers to.
 


### PR DESCRIPTION
…n should be prohibited


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/pull/786.html" title="Last updated on Nov 23, 2023, 12:28 PM UTC (818494b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/786/cb5b4b2...818494b.html" title="Last updated on Nov 23, 2023, 12:28 PM UTC (818494b)">Diff</a>