### PR TITLE
    Fix #792: Define a box for `configOBUs`.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -34,6 +34,7 @@ url: https://www.iso.org/standard/68960.html#; spec: ISO-BMFF; type: property;
 	text: trun
 	text: ctts
 	text: stss
+	text: btrt
 
 url: https://aomediacodec.github.io/av1-spec/av1-spec.pdf#; spec: AV1-Spec; type: dfn;
 	text: Clip3

--- a/index.bs
+++ b/index.bs
@@ -2016,7 +2016,7 @@ class IAConfigurationBox extends Box('iacb') {
 
 <b>Semantics</b>
 
-<dfn noexport>configurationVersion</dfn> indicates the version of the IAConfigurationBox. The value SHALL be set to 1. Parsers SHOULD ignore this box when [=configuraitonVersion=] is not set to 1.
+<dfn noexport>configurationVersion</dfn> indicates the version of the IAConfigurationBox. The value SHALL be set to 1 for this version of the specification. The box with which [=configurationVersion=] is not set to 1 SHALL be ignored by parsers compliant with this version of the specification.
 
 <dfn noexport>configOBUs_size</dfn> SHALL be set to the size of [=configOBUs=] in bytes.
 
@@ -2028,7 +2028,7 @@ class IAConfigurationBox extends Box('iacb') {
 
 NOTE: In practice, [=configOBUs=] is identical to [=Descriptors=].
 
-NOTE: `IAConfigurationBox` may contain extra data after the signaled end of [=configOBUs=]. Any extra data can be safely ignored.
+NOTE: Future versions of the specification may define fields after the signaled end of [=configOBUs=]. Parsers compliant with this version of the specification can safely ignore them.
 
 ### IA Sample Format ### {#iasampleformat}
 

--- a/index.bs
+++ b/index.bs
@@ -2026,7 +2026,7 @@ class IAConfigurationBox extends Box('iacb') {
 - One or more [=Audio Element OBU=]s
 - One or more [=Mix Presentation OBU=]s
 
-NOTE: In practice, [=configOBUs=] is the identical to [=Descriptors=].
+NOTE: In practice, [=configOBUs=] is identical to [=Descriptors=].
 
 NOTE: `IAConfigurationBox` may contain extra data after the signaled end of [=configOBUs=]. Any extra data can be safely ignored.
 

--- a/index.bs
+++ b/index.bs
@@ -1982,7 +1982,7 @@ NOTE: Multiple sample entries may be used in a track, for example when the track
 
 ```
 class IASampleEntry extends AudioSampleEntry('iamf') {
-  unsigned int (8) configOBUs[];
+    IAConfigurationBox config;
 }
 ```
 
@@ -1990,13 +1990,44 @@ The [=channelcount=] field of [=AudioSampleEntry=] SHALL be set to 0.
 The [=samplerate=] field of [=AudioSampleEntry=] SHALL be set to 0. There SHALL be no [=SamplingRateBox=].
 Parsers SHALL ignore these two fields.
 
+### IA Configuration Box ### {#iaconfigurationbox-section}
+
+<pre class="def">
+	Sample Entry Type: <dfn export for="IAConfigurationBox">iacb</dfn>
+	Container:         Ia Sample Entry ('iamf')
+	Mandatory:         Yes
+	Quantity:          One or more.
+</pre>
+
+<b>Syntax</b>
+
+```
+class IAConfigurationBox extends Box('iacb') {
+  IAConfigurationRecord IAMFConfig;
+}
+```
+
+```
+aligned(8) class IAConfigurationRecord {
+    unsigned int (8) configurationVersion = 1;
+    leb128() configOBUs_size;
+    unsigned int (8) configOBUs[];
+}
+```
+
 <b>Semantics</b>
+
+<dfn noexport>configurationVersion</dfn> indicates the version of the IAConfigurationRecord. The value SHALL be set to 1.
+
+<dfn noexport>configOBUs_size</dfn> SHALL be set to the size of [=configOBUs=] in bytes.
 
 <dfn noexport>configOBUs</dfn> SHALL contain the following OBUs in order.
 - [=IA Sequence Header OBU=]
 - [=Codec Config OBU=]
 - One or more [=Audio Element OBU=]s
 - One or more [=Mix Presentation OBU=]s
+
+NOTE: `IAConfigurationRecord` may contain extra data after the signaled end of [=configOBUs=]. Any extra data can be safely ignored.
 
 ### IA Sample Format ### {#iasampleformat}
 

--- a/index.bs
+++ b/index.bs
@@ -2010,7 +2010,7 @@ Parsers SHALL ignore these two fields.
 class IAConfigurationBox extends Box('iacb') {
     unsigned int (8) configurationVersion = 1;
     leb128() configOBUs_size;
-    unsigned int (8) configOBUs[];
+    unsigned int (8 x configOBUs_size) configOBUs;
 }
 ```
 

--- a/index.bs
+++ b/index.bs
@@ -1983,7 +1983,7 @@ NOTE: Multiple sample entries may be used in a track, for example when the track
 
 ```
 class IASampleEntry extends AudioSampleEntry('iamf') {
-    IAConfigurationBox config;
+    IAConfigurationBox ia_configuration_box;
 }
 ```
 
@@ -1991,25 +1991,23 @@ The [=channelcount=] field of [=AudioSampleEntry=] SHALL be set to 0.
 The [=samplerate=] field of [=AudioSampleEntry=] SHALL be set to 0. There SHALL be no [=SamplingRateBox=].
 Parsers SHALL ignore these two fields.
 
+<b>Semantics</b>
+
+<dfn noexport>ia_configuration_box</dfn> is an instance of the IAConfigurationBox() class, which provides the configuration of the [=IA Sequence=]. The position of the instance SHALL comply with the rule specified in [[!ISO-BMFF]] for [=AudioSampleEntry=]. In other words, the instance SHALL be present after the [=samplerate=] field of [=AudioSampleEntry=]. When the instance is present with another optional box such as the BitRateBox() ('btrt'), their exact ordering is not defined.
+
 ### IA Configuration Box ### {#iaconfigurationbox-section}
 
 <pre class="def">
 	Sample Entry Type: <dfn export for="IAConfigurationBox">iacb</dfn>
-	Container:         Ia Sample Entry ('iamf')
+	Container:         IA Sample Entry ('iamf')
 	Mandatory:         Yes
-	Quantity:          One or more.
+	Quantity:          One.
 </pre>
 
 <b>Syntax</b>
 
 ```
 class IAConfigurationBox extends Box('iacb') {
-  IAConfigurationRecord IAMFConfig;
-}
-```
-
-```
-aligned(8) class IAConfigurationRecord {
     unsigned int (8) configurationVersion = 1;
     leb128() configOBUs_size;
     unsigned int (8) configOBUs[];
@@ -2018,7 +2016,7 @@ aligned(8) class IAConfigurationRecord {
 
 <b>Semantics</b>
 
-<dfn noexport>configurationVersion</dfn> indicates the version of the IAConfigurationRecord. The value SHALL be set to 1.
+<dfn noexport>configurationVersion</dfn> indicates the version of the IAConfigurationBox. The value SHALL be set to 1. Parsers SHOULD ignore this box when [=configuraitonVersion=] is not set to 1.
 
 <dfn noexport>configOBUs_size</dfn> SHALL be set to the size of [=configOBUs=] in bytes.
 
@@ -2028,7 +2026,9 @@ aligned(8) class IAConfigurationRecord {
 - One or more [=Audio Element OBU=]s
 - One or more [=Mix Presentation OBU=]s
 
-NOTE: `IAConfigurationRecord` may contain extra data after the signaled end of [=configOBUs=]. Any extra data can be safely ignored.
+NOTE: In practice, [=configOBUs=] is the identical to [=Descriptors=].
+
+NOTE: `IAConfigurationBox` may contain extra data after the signaled end of [=configOBUs=]. Any extra data can be safely ignored.
 
 ### IA Sample Format ### {#iasampleformat}
 


### PR DESCRIPTION
- Future backwards compatible extensions can be put at the end of `IAConfigurationRecord`.
      - Future non-backwards compatible extensions will require `configurationVersion` to be bumped.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jwcullen/iamf/pull/794.html" title="Last updated on Jan 18, 2024, 10:35 PM UTC (6f3007d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/794/b5668ae...jwcullen:6f3007d.html" title="Last updated on Jan 18, 2024, 10:35 PM UTC (6f3007d)">Diff</a>