### PR TITLE
Update the date and the link of the reference implementation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10,7 +10,7 @@ URL: https://aomediacodec.github.io/iamf/
 !Previously approved version: <a href="https://aomediacodec.github.io/iamf/v1.0.0.html">https://aomediacodec.github.io/iamf/v1.0.0.html</a>
 !Latest approved version: <a href="https://aomediacodec.github.io/iamf/latest-approved.html">https://aomediacodec.github.io/iamf/latest-approved.html</a>
 !Latest draft version: <a href="https://aomediacodec.github.io/iamf/latest-draft.html">https://aomediacodec.github.io/iamf/latest-draft.html</a>
-Date: 2024-01-29
+Date: 2024-02-20
 !Reference Implementation: <a href="https://github.com/AOMediaCodec/libiamf/">libiamf</a>
 Abstract: This document specifies the Immersive Audio (IA) model, the standalone IA Sequence format, and the [[!ISO-BMFF]]-based IA container format.
 Local Boilerplate: footer yes

--- a/index.bs
+++ b/index.bs
@@ -10,8 +10,8 @@ URL: https://aomediacodec.github.io/iamf/
 !Previously approved version: <a href="https://aomediacodec.github.io/iamf/v1.0.0.html">https://aomediacodec.github.io/iamf/v1.0.0.html</a>
 !Latest approved version: <a href="https://aomediacodec.github.io/iamf/latest-approved.html">https://aomediacodec.github.io/iamf/latest-approved.html</a>
 !Latest draft version: <a href="https://aomediacodec.github.io/iamf/latest-draft.html">https://aomediacodec.github.io/iamf/latest-draft.html</a>
-Date: 2023-11-06
-!Reference Implementation: <a href="https://github.com/AOMediaCodec/libiamf/releases/tag/v1.0.0/">libiamf v1.0.0</a>
+Date: 2024-01-29
+!Reference Implementation: <a href="https://github.com/AOMediaCodec/libiamf/">libiamf</a>
 Abstract: This document specifies the Immersive Audio (IA) model, the standalone IA Sequence format, and the [[!ISO-BMFF]]-based IA container format.
 Local Boilerplate: footer yes
 Metadata Order: This version, !*, *


### PR DESCRIPTION
NOTE: For release, the reference implementation needs to be updated to indicate libiamf v1.0.0-errata1


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/pull/800.html" title="Last updated on Feb 21, 2024, 12:57 AM UTC (6a14443)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/800/1cde52c...6a14443.html" title="Last updated on Feb 21, 2024, 12:57 AM UTC (6a14443)">Diff</a>