### PR TITLE
Fix typo in `IAConfigurationBox`.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2000,10 +2000,10 @@ Parsers SHALL ignore these two fields.
 ### IA Configuration Box ### {#iaconfigurationbox-section}
 
 <pre class="def">
-	Sample Entry Type: <dfn export for="IAConfigurationBox">iacb</dfn>
-	Container:         IA Sample Entry ('iamf')
-	Mandatory:         Yes
-	Quantity:          One.
+	Box Type:  <dfn export for="IAConfigurationBox">iacb</dfn>
+	Container: IA Sample Entry ('iamf')
+	Mandatory: Yes
+	Quantity:  One.
 </pre>
 
 <b>Syntax</b>


### PR DESCRIPTION
- Not a bitstream change.
  - The style is more consistent because the `IAConfigurationBox` extends Box.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/pull/801.html" title="Last updated on Feb 6, 2024, 6:14 PM UTC (bebc08f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/801/bbb33c8...bebc08f.html" title="Last updated on Feb 6, 2024, 6:14 PM UTC (bebc08f)">Diff</a>