### PR TITLE
Remove pip cache for setup-python action.

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -23,7 +23,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.11
-          cache: 'pip'
       - run: pip install bikeshed
 
       - name: Install Poetry


### PR DESCRIPTION
A newer version of setup-python requires the project
to have a requirements.txt in its base url, but we
don't have one as we're only using bikeshed.
