### PR TITLE
Fix #815, typo correction on static down-mix matrix

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2683,8 +2683,10 @@ The 3.1.2ch down-mix matrix for 7.1.4ch is given below, where \(p = 0.707\).
 	\text{Rss} \\
 	\text{Lrs} \\
 	\text{Rrs} \\
-	\text{Ltf2} \\
-	\text{Rtf2} \\
+	\text{Ltf4} \\
+	\text{Rtf4} \\
+	\text{Ltb} \\
+	\text{Rtb} \\
 	\text{LFE}
 \end{bmatrix}
 \]


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/pull/822.html" title="Last updated on May 28, 2024, 5:57 AM UTC (1e4e4dc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/822/ac94d8d...1e4e4dc.html" title="Last updated on May 28, 2024, 5:57 AM UTC (1e4e4dc)">Diff</a>