### PR TITLE
Clarify text indicating the input layout to use for rendering

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2364,7 +2364,7 @@ This section defines the renderer to use, given a channel-based [=Audio Element=
 
 - The input layout (x.y.z) of the IA renderer is set as follows:
     - If [=num_layers=] = 1, use the [=loudspeaker_layout=] of the [=Audio Element=].
-    - Else, if there is an [=Audio Element=] with a [=loudspeaker_layout=] that matches the playback layout, use it.
+    - Else, if the [=Audio Element=] has a [=loudspeaker_layout=] that matches the playback layout, use that matching [=loudspeaker_layout=].
     - Else, use the next highest available layout from all available [=loudspeaker_layout=]s.
 - The output layout of the IA renderer is set to the playback layout (X.Y.Z).
 - The IA renderer is selected according to the following rules:


### PR DESCRIPTION
Fix #807: Selection of layout to use for pass-through rendering is ambiguous


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/pull/825.html" title="Last updated on May 28, 2024, 6:08 PM UTC (ac66f31)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/825/ac94d8d...ac66f31.html" title="Last updated on May 28, 2024, 6:08 PM UTC (ac66f31)">Diff</a>