### PR TITLE
Reword restriction on obu_size

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1827,7 +1827,7 @@ NOTE: [[#profiles-simple|Simple Profile]] or [[#profiles-base|Base Profile]] req
 NOTE: In this section and subsections, the meaning of a unique OBU is that it is still unique if it only varies by the [=obu_redundant_copy=] flag.
 
 Common restrictions on the [=IA Sequence=] for all profiles specified in this version of the specification:
-- The maximum size of an OBU (an [=OBU Header=] followed by the OBU payload) SHALL be limited to \(2\text{MB}\) (i.e., \(2^{21}\) bytes). It implies that the maximum value of the [=obu_size=] field SHALL be limited to \(2^{21} - 4\).
+- The maximum size of an OBU (an [=OBU Header=] followed by the OBU payload) SHALL be limited to \(2\text{MB}\) (i.e., \(2^{21}\) bytes). It implies that the maximum value of the [=obu_size=] field SHALL be limited to \(2^{21} - 4\), in the case where [=obu_size=] is encoded using the most compressed leb128() representation.
 - There SHALL be only one unique set of [=Descriptors=] in an [=IA Sequence=]. If the [=Descriptors=] are repeated in the middle of the [=IA Sequence=], all the OBUs in that set of [=Descriptors=] SHALL be marked as redundant (i.e., [=obu_redundant_copy=] = 1).
 	- When a set of [=Descriptors=] is placed in the middle of the [=IA Sequence=], it SHALL NOT be placed in the middle of a [=Temporal Unit=]. In other words, if [=Descriptors=] are placed mid-sequence, they SHALL be present only after the last OBU of a [=Temporal Unit=] and before the first OBU of the next [=Temporal Unit=].
 - There SHALL be only one unique [=Codec Config OBU=].


### PR DESCRIPTION
Fix #806: Clarify the obu_size restriction holds if not encoded with padded
leb128 bytes


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/pull/826.html" title="Last updated on May 28, 2024, 6:25 PM UTC (a56796b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/826/ac94d8d...a56796b.html" title="Last updated on May 28, 2024, 6:25 PM UTC (a56796b)">Diff</a>