### PR TITLE
Setting track language during ISOBMFF encapsulation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -37,6 +37,8 @@ url: https://www.iso.org/standard/83102.html#; spec: ISO-BMFF; type: property;
 	text: ctts
 	text: stss
 	text: btrt
+	text: mdhd
+	text: elng
 
 url: https://aomediacodec.github.io/av1-spec/av1-spec.pdf#; spec: AV1-Spec; type: dfn;
 	text: Clip3
@@ -2030,6 +2032,8 @@ NOTE: Multiple sample entries may be used in a track, for example when the track
 	- When the [=codec_id=] is set to <code>Opus</code> or <code>mp4a</code> in an [=IA Track=], every sample SHALL be associated with a sample group of the type 'roll'. The [=roll_distance=] value SHALL equal the value of the [=audio_roll_distance=] field in the [=Codec Config OBU=] stored in the [=configOBUs=] array in the sample entry.
 - Composition Time Stamp (CTS)
 	- For each [=IA Sample=], CTS = DTS (Decoding Time Stamp), and as a consequence, the 'ctts' box (and similar signaling in movie fragments) SHALL NOT be used.
+- Track Language
+	- An [=IA Track=] could include [=Audio Element=]s with audio content in multiple languages, or with no associated language. In this case, the language indicated in the 'mdhd' and 'elng' boxes (if provided) SHOULD use one of the following [[!ISO-639-2-Codes]] language codes: <code>mul</code> or <code>und</code>.
 
 ### IA Sample Entry ### {#iasampleentry-section}
 


### PR DESCRIPTION
Fix #830


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/pull/833.html" title="Last updated on Jun 14, 2024, 7:15 PM UTC (fecba76)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/833/eaea1b8...fecba76.html" title="Last updated on Jun 14, 2024, 7:15 PM UTC (fecba76)">Diff</a>