### PR TITLE
`auto-publish`: Upgrade deprecated ubuntu version to latest.

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   main:
     name: Compile and deploy
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
ubuntu-20.04 is [no longer supported](https://github.com/actions/runner-images/issues/11101).