### PR TITLE
Fix images to v1.1.0_images

### DIFF
--- a/v1.1.0.html
+++ b/v1.1.0.html
@@ -2268,7 +2268,7 @@ dfn > a.self-link::before      { content: "#"; }
    <h2 class="heading settled" data-level="2" id="iamodel"><span class="secno">2. </span><span class="content">Immersive Audio Model</span><a class="self-link" href="#iamodel"></a></h2>
    <h3 class="heading settled" data-level="2.1" id="model-overview"><span class="secno">2.1. </span><span class="content">Model Overview</span><a class="self-link" href="#model-overview"></a></h3>
    <p>This specification defines a model for representing <a data-link-type="dfn" href="#immersive-audio" id="ref-for-immersive-audio②">Immersive Audio</a> contents based on <a data-link-type="dfn" href="#audio-substream" id="ref-for-audio-substream">Audio Substream</a>s contributing to <a data-link-type="dfn" href="#audio-element" id="ref-for-audio-element④">Audio Element</a>s meant to be rendered and mixed to form one or more presentations as depicted in the figure below.</p>
-   <center><img src="images/decoding_flow_cropped.svg" width="800"></center>
+   <center><img src="v1.1.0_images/decoding_flow_cropped.svg" width="800"></center>
    <center>
     <figcaption>Processing flow to decode, reconstruct, render, and mix the 3D audio signals for immersive audio playback.</figcaption>
    </center>
@@ -2285,7 +2285,7 @@ dfn > a.self-link::before      { content: "#"; }
    <p>The term <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="rendered-mix-presentation">Rendered Mix Presentation</dfn> means a <a data-link-type="dfn" href="#3d-audio-signal" id="ref-for-3d-audio-signal⑦">3D audio signal</a> after the <a data-link-type="dfn" href="#audio-element" id="ref-for-audio-element①①">Audio Element</a>(s) defined in a <a data-link-type="dfn" href="#mix-presentation" id="ref-for-mix-presentation②">Mix Presentation</a> is(are) rendered and mixed together for playback through physical loudspeakers or headphones.</p>
    <h3 class="heading settled" data-level="2.2" id="architecture"><span class="secno">2.2. </span><span class="content">Architecture</span><a class="self-link" href="#architecture"></a></h3>
    <p>Based on the model, this specification defines the Immersive Audio Model and Formats (<dfn data-dfn-type="dfn" data-noexport id="iamf">IAMF<a class="self-link" href="#iamf"></a></dfn>) architecture as depicted in the figure below.</p>
-   <center><img height="837" src="images/Hypothetical IAMF Architecture.png" style="width:100%; height:auto;" width="1637"></center>
+   <center><img height="837" src="v1.1.0_images/Hypothetical IAMF Architecture.png" style="width:100%; height:auto;" width="1637"></center>
    <center>
     <figcaption>IAMF Architecture</figcaption>
    </center>
@@ -2358,7 +2358,7 @@ dfn > a.self-link::before      { content: "#"; }
    <p>Within an <a data-link-type="dfn" href="#ia-sequence" id="ref-for-ia-sequence①①">IA Sequence</a>, all <a data-link-type="dfn" href="#mix-presentation" id="ref-for-mix-presentation⑧">Mix Presentation</a>s have the same duration, defining the duration of the <a data-link-type="dfn" href="#ia-sequence" id="ref-for-ia-sequence①②">IA Sequence</a>, and have the same presentation start time defining the presentation start time of the <a data-link-type="dfn" href="#ia-sequence" id="ref-for-ia-sequence①③">IA Sequence</a>.</p>
    <p>The term <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="temporal-unit">Temporal Unit</dfn> conceptually means a set of all <a data-link-type="dfn" href="#audio-frame-obu" id="ref-for-audio-frame-obu①①">Audio Frame OBU</a>s with the same decode start time and the same duration from all coded <a data-link-type="dfn" href="#audio-substream" id="ref-for-audio-substream②⑤">Audio Substream</a>s and all non-redundant <a data-link-type="dfn" href="#parameter-block-obu" id="ref-for-parameter-block-obu①⓪">Parameter Block OBU</a>s with the decode start time within the duration.</p>
    <p>The figure below shows an example of the Timing Model in terms of the decode start times and durations of the coded <a data-link-type="dfn" href="#audio-substream" id="ref-for-audio-substream②⑥">Audio Substream</a> and <a data-link-type="dfn" href="#parameter-substream" id="ref-for-parameter-substream①⑥">Parameter Substream</a>.</p>
-   <center><img height="1029" src="images/IAMF Timing Model.png" style="width:100%; height:auto;" width="1943"></center>
+   <center><img height="1029" src="v1.1.0_images/IAMF Timing Model.png" style="width:100%; height:auto;" width="1943"></center>
    <center>
     <figcaption>An example of the IAMF Timing Model. AFO: <a data-link-type="dfn" href="#audio-frame-obu" id="ref-for-audio-frame-obu①②">Audio Frame OBU</a>, PBO: <a data-link-type="dfn" href="#parameter-block-obu" id="ref-for-parameter-block-obu①①">Parameter Block OBU</a>, \(\text{PT}x\): time \(x\) (ms) on the presentation layer’s timeline, \(\text{DT}y\): time \(y\) (ms) on the decoding layer’s timeline.</figcaption>
    </center>
@@ -3018,7 +3018,7 @@ class ChannelAudioLayerConfig(i) {
     <li data-md>
      <p><a data-link-type="dfn" href="#parameter-block-obu" id="ref-for-parameter-block-obu①⑥">Parameter Block OBU</a>s MAY be associated with Audio Frames.</p>
    </ul>
-   <center><img height="356" src="images/Immersive Audio Sequence with scalable channel audio (before OBU packing).png" style="width:100%; height:auto;" width="1622"></center>
+   <center><img height="356" src="v1.1.0_images/Immersive Audio Sequence with scalable channel audio (before OBU packing).png" style="width:100%; height:auto;" width="1622"></center>
    <center>
     <figcaption>Immersive Audio Sequence with scalable channel audio (before OBU packing). See <a href="#standalone">§ 5 Standalone IAMF Representation</a> for related details on OBU ordering within an IA Sequence.</figcaption>
    </center>
@@ -3040,7 +3040,7 @@ class ChannelAudioLayerConfig(i) {
      <p>\(CL \text{#}i\) is one of the <a data-link-type="dfn" href="#loudspeaker_layout" id="ref-for-loudspeaker_layout①⑤">loudspeaker_layout</a>s supported in this version of the specification.</p>
    </ul>
    <p>Scalable channel audio with <a data-link-type="dfn" href="#num_layers" id="ref-for-num_layers⑦">num_layers</a> \(> 1\) SHALL only allow down-mix paths that conform to the rules above, as depicted in the figure below.</p>
-   <center><img height="729" src="images/Down-mix Path.png" style="width:90%; height:auto;" width="878"></center>
+   <center><img height="729" src="v1.1.0_images/Down-mix Path.png" style="width:90%; height:auto;" width="878"></center>
    <center>
     <figcaption>IA Down-mix Path for scalable channel audio</figcaption>
    </center>
@@ -3550,7 +3550,7 @@ class AnimatedParameterData(animation_type) {
      <p>7: Reserved for future use</p>
    </ul>
    <p>\(\alpha\) and \(\beta\) are gain values used for the <a data-link-type="dfn" href="#s7to5-encoder" id="ref-for-s7to5-encoder">S7to5 encoder</a>, \(\gamma\) for the <a data-link-type="dfn" href="#t4to2-encoder" id="ref-for-t4to2-encoder">T4to2 encoder</a>, \(\delta\) for the <a data-link-type="dfn" href="#s5to3-encoder" id="ref-for-s5to3-encoder">S5to3 encoder</a> and <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="w_idx_offset">w_idx_offset</dfn> is the offset used to generate a gain value <a data-link-type="dfn" href="#w-k" id="ref-for-w-k③">\(w(k)\)</a> used for <a data-link-type="dfn" href="#t2totf2-encoder" id="ref-for-t2totf2-encoder">T2toTF2 encoder</a>.</p>
-   <center><img height="600" src="images/Down-mix Mechanism.png" style="width:100%; height:auto;" width="1306"></center>
+   <center><img height="600" src="v1.1.0_images/Down-mix Mechanism.png" style="width:100%; height:auto;" width="1306"></center>
    <center>
     <figcaption>IA Down-mix Mechanism</figcaption>
    </center>
@@ -3831,7 +3831,7 @@ the 1st byte :      b4      : Right surround channel (or Rss)
    <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="ia-sequence">IA Sequence</dfn> is composed of a series of OBUs in the sequence of a set of <a data-link-type="dfn" href="#descriptors" id="ref-for-descriptors②⓪">Descriptors</a> followed by their associated <a data-link-type="dfn" href="#ia-data" id="ref-for-ia-data②">IA Data</a>.</p>
    <p>The <a data-link-type="dfn" href="#descriptors" id="ref-for-descriptors②①">Descriptors</a> MAY additionally be repeated redundantly and as frequently as necessary. In this case, the <a data-link-type="dfn" href="#obu_redundant_copy" id="ref-for-obu_redundant_copy⑤">obu_redundant_copy</a> field in their <a data-link-type="dfn" href="#obu-header" id="ref-for-obu-header⑤">OBU Header</a>s SHALL be set to 1. Within an <a data-link-type="dfn" href="#ia-sequence" id="ref-for-ia-sequence⑤③">IA Sequence</a>, each OBU in the first <a data-link-type="dfn" href="#descriptors" id="ref-for-descriptors②②">Descriptors</a> SHALL be regarded as a non-redundant OBU regardless of the value of its <a data-link-type="dfn" href="#obu_redundant_copy" id="ref-for-obu_redundant_copy⑥">obu_redundant_copy</a>.</p>
    <p>The figure below shows an example of an <a data-link-type="dfn" href="#ia-sequence" id="ref-for-ia-sequence⑤④">IA Sequence</a>.</p>
-   <center><img height="445" src="images/IA sequence.png" style="width:100%; height:auto;" width="1430"></center>
+   <center><img height="445" src="v1.1.0_images/IA sequence.png" style="width:100%; height:auto;" width="1430"></center>
    <center>
     <figcaption>Example of an Immersive Audio Sequence</figcaption>
    </center>
@@ -4055,7 +4055,7 @@ Quantity:  One.
    </ol>
    <h4 class="heading settled" data-level="6.5.2" id="isobmff-decapsulation-singletrack-trimming"><span class="secno">6.5.2. </span><span class="content">Handling Trimming Information</span><a class="self-link" href="#isobmff-decapsulation-singletrack-trimming"></a></h4>
    <p>This section provides a guideline for handling trimming information in an ISO-BMFF file.</p>
-   <center><img height="639" src="images/ISOBMFF Trimming Handling.png" style="width:80%; height:auto;" width="819"></center>
+   <center><img height="639" src="v1.1.0_images/ISOBMFF Trimming Handling.png" style="width:80%; height:auto;" width="819"></center>
    <center>
     <figcaption>Recommendation for handling ISO-BMFF trimming information. PTS is the presentation start time. PTS1 is the presentation start time of the first audio sample before trimming. PTS2 is the presentation start time of the first audio sample after trimming.</figcaption>
    </center>
@@ -4129,7 +4129,7 @@ Quantity:  One.
    </ol>
    <p class="note" role="note"><span>NOTE:</span> The IA decoder may choose to lazily parse OBUs to avoid unnecessarily parsing OBUs that are not used by the selected <a data-link-type="dfn" href="#mix-presentation" id="ref-for-mix-presentation③⑤">Mix Presentation</a>.</p>
    <p>The figure below depicts an example of IA decoder architecture with modules that perform the steps above.</p>
-   <center><img height="700" src="images/IA Decoder Configuration.png" style="width:100%; height:auto;" width="1908"></center>
+   <center><img height="700" src="v1.1.0_images/IA Decoder Configuration.png" style="width:100%; height:auto;" width="1908"></center>
    <center>
     <figcaption>IA Decoder Configuration. AE: Audio Element, AS: Audio Substream.</figcaption>
    </center>
@@ -4150,7 +4150,7 @@ Quantity:  One.
    <h3 class="heading settled" data-level="7.1" id="processing-ambisonics"><span class="secno">7.1. </span><span class="content">Ambisonics Decoding and Reconstruction</span><a class="self-link" href="#processing-ambisonics"></a></h3>
    <p>The reconstruction of an Ambisonics signal SHALL conform to <a data-link-type="biblio" href="#biblio-rfc-8486">[RFC-8486]</a>, with the exception that a codec other than Opus MAY be used.</p>
    <p>The figure below shows the decoding and reconstruction flowchart.</p>
-   <center><img height="361" src="images/Ambisonics Decoding Flowchart.png" style="width:80%; height:auto;" width="613"></center>
+   <center><img height="361" src="v1.1.0_images/Ambisonics Decoding Flowchart.png" style="width:80%; height:auto;" width="613"></center>
    <center>
     <figcaption>Ambisonics Decoding and Reconstruction Flowchart</figcaption>
    </center>
@@ -4176,7 +4176,7 @@ Quantity:  One.
    <p>This section describes the decoding and reconstruction of a Scalable Channel Audio representation.</p>
    <p>The output of this process SHALL be the <a data-link-type="dfn" href="#3d-audio-signal" id="ref-for-3d-audio-signal①⑧">3D audio signal</a> (e.g., 3.1.2ch or 7.1.4ch) for the target channel layout.</p>
    <p>The figure below shows the decoding and reconstruction flowchart.</p>
-   <center><img height="605" src="images/Channel Audio Decoding Flowchart.png" style="width:80%; height:auto;" width="600"></center>
+   <center><img height="605" src="v1.1.0_images/Channel Audio Decoding Flowchart.png" style="width:80%; height:auto;" width="600"></center>
    <center>
     <figcaption>Scalable Channel Audio Decoding and Reconstruction Flowchart</figcaption>
    </center>
@@ -4336,7 +4336,7 @@ where i = 1, 2, ..., n and \(n\) is <a data-link-type="dfn" href="#num_layers" i
      </ul>
    </ul>
    <p>The figure below shows the smoothing scheme of <a data-link-type="dfn" href="#recon_gain" id="ref-for-recon_gain⑧">recon_gain</a>.</p>
-   <center><img height="334" src="images/Smoothing Scheme of Recon Gain.png" style="width:100%; height:auto;" width="1513"></center>
+   <center><img height="334" src="v1.1.0_images/Smoothing Scheme of Recon Gain.png" style="width:100%; height:auto;" width="1513"></center>
    <center>
     <figcaption>Smoothing Scheme of Recon Gain</figcaption>
    </center>
@@ -4967,7 +4967,7 @@ class Bar {
      <p>A list of channel layouts to be supported for scalable channel audio, which conforms to <a data-link-type="dfn" href="#loudspeaker_layout" id="ref-for-loudspeaker_layout③③">loudspeaker_layout</a>.</p>
    </ul>
    <p>The figure below shows an example architecture for an IA encoder that generates an <a data-link-type="dfn" href="#ia-sequence" id="ref-for-ia-sequence⑧①">IA Sequence</a> with one <a data-link-type="dfn" href="#audio-element" id="ref-for-audio-element①①⑧">Audio Element</a>.</p>
-   <center><img height="632" src="images/IA Encoder Configuration.png" style="width:100%; height:auto;" width="1852"></center>
+   <center><img height="632" src="v1.1.0_images/IA Encoder Configuration.png" style="width:100%; height:auto;" width="1852"></center>
    <center>
     <figcaption>IA Encoder Configuration</figcaption>
    </center>
@@ -5119,7 +5119,7 @@ class Bar {
      </ul>
    </ul>
    <p>The figure below shows the IA encoding flowchart for Scalable Channel Audio.</p>
-   <center><img height="667" src="images/IA Encoding Flowchart for Channel Audio Format.png" style="width:80%; height:auto;" width="1023"></center>
+   <center><img height="667" src="v1.1.0_images/IA Encoding Flowchart for Channel Audio Format.png" style="width:80%; height:auto;" width="1023"></center>
    <center>
     <figcaption>IA Encoding Flowchart for Scalable Channel Audio. CH: channel </figcaption>
    </center>
@@ -5168,7 +5168,7 @@ class Bar {
    <h5 class="heading settled" data-level="10.1.2.1" id="iamfgeneration-scalablechannelaudio-downmixparameter"><span class="secno">10.1.2.1. </span><span class="content">Annex A2.1: Down-mix parameter and Loudness (Informative)</span><a class="self-link" href="#iamfgeneration-scalablechannelaudio-downmixparameter"></a></h5>
    <p>This section describes how down-mix parameters and loudness levels can be generated for a given channel audio and a given list of channel layouts for scalability (i.e., <a data-link-type="dfn" href="#num_layers" id="ref-for-num_layers②④">num_layers</a> > 1).</p>
    <p>The figure below shows a block diagram for the Down-Mix Parameter Generator and Loudness Module, including the Down-Mixer.</p>
-   <center><img height="651" src="images/Down-mix Parameter and Loudness.png" style="width:100%; height:auto;" width="1382"></center>
+   <center><img height="651" src="v1.1.0_images/Down-mix Parameter and Loudness.png" style="width:100%; height:auto;" width="1382"></center>
    <center>
     <figcaption>IA Down-Mix Parameter and Loudness</figcaption>
    </center>
@@ -5243,7 +5243,7 @@ class Bar {
 \[\text{Rtf3} = \text{Rtf2} + w(k) \times \delta(k) \times \text{Rs5}\]</p>
      </ul>
    </ul>
-   <center><img height="600" src="images/Down-mix Mechanism.png" style="width:100%; height:auto;" width="1306"></center>
+   <center><img height="600" src="v1.1.0_images/Down-mix Mechanism.png" style="width:100%; height:auto;" width="1306"></center>
    <center>
     <figcaption>IA Down-mix Mechanism</figcaption>
    </center>
@@ -5541,7 +5541,7 @@ where
    </ol>
    <h3 class="heading settled" data-level="10.2" id="idlinkingscheme"><span class="secno">10.2. </span><span class="content">Annex B: ID Linking Scheme (Informative)</span><a class="self-link" href="#idlinkingscheme"></a></h3>
    <p>The figure below shows the linking scheme among IDs in the obu_header or OBU payload.</p>
-   <center><img height="1048" src="images/ID Linking Example.png" style="width:100%; height:auto;" width="1783"></center>
+   <center><img height="1048" src="v1.1.0_images/ID Linking Example.png" style="width:100%; height:auto;" width="1783"></center>
    <center>
     <figcaption>ID Linking Scheme</figcaption>
    </center>


### PR DESCRIPTION
Image sources are changed from "images" to "v1.1.0_images" to align with the styles of v1.0.0-errata.html