### PR TITLE
Update auto-publish.yml

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -53,7 +53,7 @@ jobs:
           cp -r images dist
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: ./dist
 


### PR DESCRIPTION
The version of GitHub Actions is updated from v3 to v4 as v3 was deprecated.
(https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)