### PR TITLE
Fix lint warnings about lines starting with spaces

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -666,14 +666,14 @@ class AudioElementOBU() {
 	leb128() audio_element_id;
 	unsigned int (3) audio_element_type;
 	unsigned int (5) reserved_for_future_use;
-  
+
 	leb128() codec_config_id;  
 
 	leb128() num_substreams;
 	for (i = 0; i < num_substreams; i++) {
 		leb128() audio_substream_id;
 	}
-  
+
 	leb128() num_parameters;
 	for (i = 0; i < num_parameters; i++) {
 		leb128() param_definition_type;
@@ -1375,7 +1375,7 @@ The <dfn noexport>Layout()</dfn> class specifies either a binaural system or a s
 ```
 class Layout() {
 	unsigned int (2) layout_type;
-  
+
 	if (layout_type == LOUDSPEAKERS_SS_CONVENTION) {
 		unsigned int (4) sound_system;
 		unsigned int (2) reserved_for_future_use;
@@ -1542,12 +1542,12 @@ The metadata specified in this OBU is used in conjunction with a corresponding p
 ```
 class ParameterBlockOBU() {
 	leb128() parameter_id;
-  
+
 	(param_definition_type, param_definition_mode, 
 	duration, num_subblocks, constant_subblock_duration, 
 	subblock_duration) 
 		= get_param_definition(parameter_id);
-  
+
 	if (param_definition_mode) {
 		leb128() duration;
 		leb128() constant_subblock_duration;


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/felicialim/iamf/pull/883.html" title="Last updated on Jun 5, 2025, 7:23 PM UTC (19f6e54)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iamf/883/4a8e8a9...felicialim:19f6e54.html" title="Last updated on Jun 5, 2025, 7:23 PM UTC (19f6e54)">Diff</a>